### PR TITLE
Add roadmap and polish API consumers

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -5,7 +5,13 @@ from .serializers import (AirportSerializer, FrequencySerializer, SpottingLocati
                           BadgeSerializer, UserBadgeSerializer)
 
 class AirportViewSet(viewsets.ModelViewSet):
-    queryset = Airport.get_queryset().order_by("icao") if hasattr(Airport, "get_queryset") else Airport.objects.all().order_by("icao")
+    """Expose airports with their related frequencies and spotting locations."""
+
+    queryset = (
+        Airport.objects.all()
+        .prefetch_related("frequencies", "spots")
+        .order_by("icao")
+    )
     serializer_class = AirportSerializer
     permission_classes = [permissions.AllowAny]
 
@@ -15,7 +21,7 @@ class FrequencyViewSet(viewsets.ModelViewSet):
     permission_classes = [permissions.AllowAny]
 
 class SpottingLocationViewSet(viewsets.ModelViewSet):
-    queryset = SpottingLocation.objects.all()
+    queryset = SpottingLocation.objects.select_related("airport").all()
     serializer_class = SpottingLocationSerializer
     permission_classes = [permissions.AllowAny]
 

--- a/docs/review-and-roadmap.md
+++ b/docs/review-and-roadmap.md
@@ -1,0 +1,63 @@
+# Plane Spotter Progress Review & Cross-Platform Roadmap
+
+## Current State Summary
+
+### Backend (Django + DRF)
+- **Models** already cover airports, frequencies, spotting locations, user logs, community posts, and badges. The schema is a solid foundation for the data plane spotters need.
+- **ViewSets** expose CRUD endpoints via the DRF router, and JWT authentication is wired up with `rest_framework_simplejwt`.
+- **Settings** enable CORS for development, static/media hosting, and SQLite by default. This is enough for local development but needs hardening for production.
+
+### Web Frontend (Next.js 15 + Tailwind)
+- Landing page plus early sections for Airports and Maps are in place.
+- API access is centralised in `lib/api.ts`, but only a `GET` helper exists and the login screen was still a placeholder.
+- Styling uses Tailwind with server components, giving us a good base for re-use later.
+
+## Key Improvements Made in This Iteration
+- ✅ Fixed the login screen to authenticate against the Django JWT endpoint and store the token locally (this mirrors the flow you can re-use on mobile).
+- ✅ Added an airport detail page that surfaces frequencies and spotting locations – a pattern to follow for other resources.
+- ✅ Tightened backend querysets to prefetch related data so that the API delivers richer responses efficiently.
+- ✅ Added this roadmap to capture architecture decisions and next steps.
+
+## Recommended Next Steps
+
+### 1. Establish a Shared Design System
+- Extract commonly styled components (buttons, cards, typography) into a package that can be consumed by both Next.js and React Native via [`@expo/html-elements`](https://docs.expo.dev/versions/latest/sdk/html-elements/) or by using [`react-native-web`](https://necolas.github.io/react-native-web/).
+- Consider a monorepo structure (Turborepo or Nx) with `apps/web`, `apps/mobile`, and `packages/ui` to share logic.
+
+### 2. Create a Mobile Client with Expo
+- Initialise an Expo project (`npx create-expo-app mobile`) configured with Expo Router for parity with Next.js routing.
+- Install `expo-router`, `expo-secure-store` (for JWT storage), and `react-query`/`tanstack-query` for data fetching.
+- Mirror the API helpers from `web/lib/api.ts`, exposing `apiGet`, `apiPost`, etc., but wrap fetch calls with Expo-specific headers when needed.
+
+### 3. Align Authentication Across Platforms
+- Move JWT management to a shared utility (e.g., `packages/auth`) that:
+  - Persists tokens (`localStorage` on web, `SecureStore` on mobile).
+  - Exposes hooks like `useAuth()` to retrieve the current user and refresh tokens automatically.
+- Add refresh token rotation and backend endpoints for password reset / social logins if required.
+
+### 4. Enhance API Capability
+- Implement pagination, search, and filtering on the airport and spotting location endpoints using DRF features (`SearchFilter`, `OrderingFilter`).
+- Add custom endpoints for derived data the mobile app will need (e.g., nearest airports by coordinates, user stats dashboards).
+- Document the API with OpenAPI/Swagger via `drf-spectacular` and publish the schema for mobile consumption.
+
+### 5. Offline-Ready Data Layer
+- Define TypeScript interfaces in a shared package and generate them from the OpenAPI schema to prevent drift.
+- On mobile, use libraries like [`react-query`](https://tanstack.com/query) with persistent caches or SQLite (`expo-sqlite`) to offer offline support for recently viewed airports/locations.
+
+### 6. Map & Geolocation Parity
+- Standardise map rendering via Mapbox/MapLibre:
+  - Web already uses MapLibre GL. For mobile, adopt [`@rnmapbox/maps`](https://github.com/rnmapbox/maps) (Mapbox GL) or `react-native-maplibre-gl` for feature parity.
+  - Create a shared JSON schema for map layers (spotting locations, runways) that both clients read.
+
+### 7. Continuous Delivery & QA
+- Set up Docker containers or GitHub Actions workflows to run `pytest`, `eslint`, `tsc`, and future mobile E2E tests.
+- Automate Expo builds with EAS for both iOS and Android; integrate Web deploys to Vercel.
+
+## Suggested Milestones
+1. **Design System & Monorepo Skeleton** – shared UI + API helpers, lint/test pipelines.
+2. **Authentication Across Clients** – login, registration, token refresh in web + mobile.
+3. **Core Features Parity** – airport browser, maps, logbook sync across platforms.
+4. **Community & Gamification** – posts, comments, badges with push notifications on mobile.
+5. **Offline & Performance** – caching strategies, background sync, metrics.
+
+Following these steps will let you scale from the current prototype into a cohesive cross-platform experience with minimal duplication.

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -1,7 +1,0 @@
-export const API_BASE = process.env.NEXT_PUBLIC_API_BASE || "http://127.0.0.1:8000/api";
-
-export async function apiGet<T>(path: string): Promise<T> {
-  const res = await fetch(`${API_BASE}${path}`, { cache: "no-store" });
-  if (!res.ok) throw new Error(`GET ${path} failed: ${res.status}`);
-  return res.json();
-}

--- a/web/src/app/airports/[id]/page.tsx
+++ b/web/src/app/airports/[id]/page.tsx
@@ -1,0 +1,102 @@
+import Link from "next/link";
+import { apiGet } from "@/lib/api";
+
+type Frequency = {
+  id: number;
+  service: string;
+  mhz: string;
+  description: string;
+};
+
+type SpottingLocation = {
+  id: number;
+  title: string;
+  description: string;
+  tips: string;
+  lat: number;
+  lon: number;
+};
+
+type Airport = {
+  id: number;
+  icao: string;
+  iata: string;
+  name: string;
+  city: string;
+  country: string;
+  lat: number;
+  lon: number;
+  frequencies: Frequency[];
+  spots: SpottingLocation[];
+};
+
+type PageProps = {
+  params: Promise<{ id: string }>;
+};
+
+export default async function AirportDetailPage({ params }: PageProps) {
+  const { id } = await params;
+  const airport = await apiGet<Airport>(`/airports/${id}/`);
+
+  return (
+    <main className="p-8 max-w-4xl mx-auto space-y-8">
+      <div className="space-y-2">
+        <Link href="/airports" className="text-sm text-blue-600 hover:underline">
+          ← Back to all airports
+        </Link>
+        <h1 className="text-3xl font-bold">
+          {airport.icao} · {airport.name}
+        </h1>
+        <p className="text-gray-600">
+          {airport.city}, {airport.country}
+        </p>
+        <p className="text-sm text-gray-500">
+          Coordinates: {airport.lat.toFixed(4)}, {airport.lon.toFixed(4)}
+        </p>
+      </div>
+
+      <section>
+        <h2 className="text-2xl font-semibold mb-3">Frequencies</h2>
+        {airport.frequencies.length === 0 ? (
+          <p className="text-gray-600">No frequencies have been added yet.</p>
+        ) : (
+          <div className="grid gap-4 md:grid-cols-2">
+            {airport.frequencies.map((freq) => (
+              <article key={freq.id} className="rounded-xl border bg-white p-4 shadow-sm">
+                <h3 className="text-lg font-semibold text-gray-900">{freq.service}</h3>
+                <p className="text-blue-600 font-mono text-sm">{Number(freq.mhz).toFixed(3)} MHz</p>
+                {freq.description ? (
+                  <p className="text-gray-600 mt-2 text-sm">{freq.description}</p>
+                ) : null}
+              </article>
+            ))}
+          </div>
+        )}
+      </section>
+
+      <section>
+        <h2 className="text-2xl font-semibold mb-3">Spotting Locations</h2>
+        {airport.spots.length === 0 ? (
+          <p className="text-gray-600">No spotting locations recorded yet. Be the first to add one!</p>
+        ) : (
+          <div className="space-y-4">
+            {airport.spots.map((spot) => (
+              <article key={spot.id} className="rounded-xl border bg-white p-5 shadow-sm">
+                <h3 className="text-lg font-semibold text-gray-900">{spot.title}</h3>
+                {spot.description ? <p className="text-gray-700 mt-2">{spot.description}</p> : null}
+                <p className="text-sm text-gray-500 mt-3">
+                  Coordinates: {spot.lat.toFixed(4)}, {spot.lon.toFixed(4)}
+                </p>
+                {spot.tips ? (
+                  <p className="mt-3 rounded-lg bg-blue-50 px-3 py-2 text-sm text-blue-700">
+                    <strong className="font-semibold">Tips:</strong> {spot.tips}
+                  </p>
+                ) : null}
+              </article>
+            ))}
+          </div>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -1,28 +1,100 @@
 "use client";
 
-import { useEffect, useRef } from "react";
-import maplibregl from "maplibre-gl";
+import { FormEvent, useState } from "react";
+import { useRouter } from "next/navigation";
+import { apiPost } from "@/lib/api";
 
-export default function MapsPage() {
-  const mapRef = useRef<HTMLDivElement>(null);
+const TOKEN_STORAGE_KEY = "plane-spotter-token";
+const REFRESH_STORAGE_KEY = "plane-spotter-refresh";
 
-  useEffect(() => {
-    if (!mapRef.current) return;
+type TokenResponse = {
+  access: string;
+  refresh: string;
+};
 
-    const map = new maplibregl.Map({
-      container: mapRef.current,
-      style: "https://basemaps.cartocdn.com/gl/positron-gl-style/style.json", // 🗺️ nicer basemap
-      center: [-0.4543, 51.4700], // Heathrow
-      zoom: 9,
-    });
+export default function LoginPage() {
+  const router = useRouter();
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
-    return () => map.remove();
-  }, []);
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setLoading(true);
+    setError(null);
+
+    try {
+      const data = await apiPost<TokenResponse>("/auth/token/", {
+        username,
+        password,
+      });
+
+      localStorage.setItem(TOKEN_STORAGE_KEY, data.access);
+      localStorage.setItem(REFRESH_STORAGE_KEY, data.refresh);
+      router.push("/");
+    } catch (err) {
+      console.error(err);
+      setError("Invalid username or password. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  };
 
   return (
-    <main className="p-8">
-      <h1 className="text-3xl font-bold mb-4">Maps</h1>
-      <div ref={mapRef} className="w-full h-[600px] rounded-xl border shadow" />
+    <main className="min-h-screen flex items-center justify-center bg-gray-100 px-6 py-12">
+      <div className="w-full max-w-md rounded-2xl bg-white p-8 shadow-lg">
+        <h1 className="text-3xl font-semibold text-center text-blue-600 mb-6">
+          Sign in to Plane Spotter
+        </h1>
+        <p className="text-gray-600 text-center mb-6">
+          Use the same credentials everywhere – the mobile clients will reuse this JWT flow.
+        </p>
+        <form onSubmit={handleSubmit} className="space-y-5">
+          <div>
+            <label htmlFor="username" className="block text-sm font-medium text-gray-700">
+              Username
+            </label>
+            <input
+              id="username"
+              value={username}
+              onChange={(event) => setUsername(event.target.value)}
+              required
+              className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+              placeholder="spotter123"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="password" className="block text-sm font-medium text-gray-700">
+              Password
+            </label>
+            <input
+              id="password"
+              type="password"
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              required
+              className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+              placeholder="••••••••"
+            />
+          </div>
+
+          {error ? (
+            <p className="text-sm text-red-600" role="alert">
+              {error}
+            </p>
+          ) : null}
+
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full rounded-lg bg-blue-600 py-2 text-white font-semibold hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-400 disabled:opacity-60"
+          >
+            {loading ? "Signing in…" : "Sign in"}
+          </button>
+        </form>
+      </div>
     </main>
   );
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,0 +1,45 @@
+export const API_BASE = process.env.NEXT_PUBLIC_API_BASE || "http://127.0.0.1:8000/api";
+
+type RequestOptions = {
+  method?: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+  body?: unknown;
+  token?: string | null;
+  cache?: RequestCache;
+};
+
+async function apiRequest<T>(path: string, options: RequestOptions = {}): Promise<T> {
+  const { method = "GET", body, token, cache = "no-store" } = options;
+  const headers: HeadersInit = {
+    "Content-Type": "application/json",
+  };
+
+  if (token) {
+    headers["Authorization"] = `Bearer ${token}`;
+  }
+
+  const res = await fetch(`${API_BASE}${path}`, {
+    method,
+    headers,
+    cache,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`${method} ${path} failed: ${res.status} ${text}`.trim());
+  }
+
+  if (res.status === 204) {
+    return undefined as T;
+  }
+
+  return res.json();
+}
+
+export async function apiGet<T>(path: string, token?: string | null): Promise<T> {
+  return apiRequest<T>(path, { method: "GET", token });
+}
+
+export async function apiPost<T>(path: string, body: unknown, token?: string | null): Promise<T> {
+  return apiRequest<T>(path, { method: "POST", body, token });
+}


### PR DESCRIPTION
## Summary
- document the current progress and outline the cross-platform roadmap
- optimise airport and spotting querysets for richer API responses
- expand the web API helper, implement JWT login, and add an airport detail page

## Testing
- npm run lint
- python manage.py check *(fails: Django not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd444a5e6c8324ab8afe258441cf37