### PR TITLE
Add forum topics, challenges, and community feed endpoint

### DIFF
--- a/core/migrations/0002_forum_topics_and_challenges.py
+++ b/core/migrations/0002_forum_topics_and_challenges.py
@@ -1,0 +1,56 @@
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ("core", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="ForumTopic",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("slug", models.SlugField(max_length=64, unique=True)),
+                ("title", models.CharField(max_length=120)),
+                ("description", models.TextField(blank=True)),
+                ("order", models.PositiveIntegerField(default=0)),
+            ],
+            options={"ordering": ("order", "title")},
+        ),
+        migrations.AddField(
+            model_name="post",
+            name="topic",
+            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name="posts", to="core.forumtopic"),
+        ),
+        migrations.CreateModel(
+            name="Challenge",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("code", models.CharField(max_length=60, unique=True)),
+                ("title", models.CharField(max_length=150)),
+                ("description", models.TextField()),
+                ("start", models.DateField()),
+                ("end", models.DateField()),
+                ("target_count", models.PositiveIntegerField(default=1)),
+                ("badge_reward", models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, to="core.badge")),
+            ],
+            options={"ordering": ("-start",)},
+        ),
+        migrations.CreateModel(
+            name="UserChallengeProgress",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("progress", models.PositiveIntegerField(default=0)),
+                ("completed", models.BooleanField(default=False)),
+                ("last_updated", models.DateTimeField(auto_now=True)),
+                ("challenge", models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name="participants", to="core.challenge")),
+                ("user", models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name="challenges", to=settings.AUTH_USER_MODEL)),
+            ],
+            options={"unique_together": {("user", "challenge")}},
+        ),
+    ]

--- a/core/serializers.py
+++ b/core/serializers.py
@@ -1,5 +1,23 @@
 from rest_framework import serializers
-from .models import Airport, Frequency, SpottingLocation, Photo, Aircraft, UserSeen, Post, Comment, Badge, UserBadge
+from django.contrib.auth import get_user_model
+from .models import (
+    Airport,
+    Frequency,
+    SpottingLocation,
+    Photo,
+    Aircraft,
+    UserSeen,
+    Post,
+    Comment,
+    Badge,
+    UserBadge,
+    ForumTopic,
+    Challenge,
+    UserChallengeProgress,
+)
+
+
+User = get_user_model()
 
 class FrequencySerializer(serializers.ModelSerializer):
     class Meta:
@@ -18,6 +36,12 @@ class AirportSerializer(serializers.ModelSerializer):
         model = Airport
         fields = "__all__"
 
+
+class ForumTopicSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ForumTopic
+        fields = "__all__"
+
 class PhotoSerializer(serializers.ModelSerializer):
     class Meta:
         model = Photo
@@ -34,9 +58,20 @@ class UserSeenSerializer(serializers.ModelSerializer):
         fields = "__all__"
 
 class PostSerializer(serializers.ModelSerializer):
+    user_display = serializers.SerializerMethodField()
+    comment_count = serializers.SerializerMethodField()
+    topic = serializers.PrimaryKeyRelatedField(queryset=ForumTopic.objects.all(), allow_null=True, required=False)
+
     class Meta:
         model = Post
         fields = "__all__"
+
+    def get_user_display(self, obj):
+        username_field = getattr(User, "USERNAME_FIELD", "username")
+        return getattr(obj.user, username_field, str(obj.user))
+
+    def get_comment_count(self, obj):
+        return getattr(obj, "comment_count", obj.comments.count())
 
 class CommentSerializer(serializers.ModelSerializer):
     class Meta:
@@ -49,7 +84,33 @@ class BadgeSerializer(serializers.ModelSerializer):
         fields = "__all__"
 
 class UserBadgeSerializer(serializers.ModelSerializer):
+    user_display = serializers.SerializerMethodField()
+    badge_name = serializers.CharField(source="badge.name", read_only=True)
+
     class Meta:
         model = UserBadge
         fields = "__all__"
+
+    def get_user_display(self, obj):
+        username_field = getattr(User, "USERNAME_FIELD", "username")
+        return getattr(obj.user, username_field, str(obj.user))
+
+
+class ChallengeSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Challenge
+        fields = "__all__"
+
+
+class UserChallengeProgressSerializer(serializers.ModelSerializer):
+    user_display = serializers.SerializerMethodField()
+    challenge_title = serializers.CharField(source="challenge.title", read_only=True)
+
+    class Meta:
+        model = UserChallengeProgress
+        fields = "__all__"
+
+    def get_user_display(self, obj):
+        username_field = getattr(User, "USERNAME_FIELD", "username")
+        return getattr(obj.user, username_field, str(obj.user))
 

--- a/core/tests.py
+++ b/core/tests.py
@@ -1,3 +1,68 @@
-from django.test import TestCase
+from datetime import date, timedelta
 
-# Create your tests here.
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+from .models import (
+    Airport,
+    Badge,
+    Challenge,
+    ForumTopic,
+    Post,
+    UserBadge,
+    UserChallengeProgress,
+)
+from .serializers import UserChallengeProgressSerializer
+
+
+class CommunityFeedViewTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.user = get_user_model().objects.create_user("spotter", "spotter@example.com", "password123")
+        self.topic = ForumTopic.objects.create(slug="general", title="General Chat")
+        self.airport = Airport.objects.create(
+            icao="EGLL",
+            iata="LHR",
+            name="Heathrow",
+            city="London",
+            country="United Kingdom",
+            lat=51.47,
+            lon=-0.4543,
+        )
+        self.post = Post.objects.create(user=self.user, title="First trip", body="Loved the spotting weekend!", topic=self.topic, airport=self.airport)
+        self.badge = Badge.objects.create(code="FIRST_POST", name="First Post", description="Shared your first post")
+        UserBadge.objects.create(user=self.user, badge=self.badge)
+
+    def test_feed_returns_posts_and_badges(self):
+        url = reverse("community-feed")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertTrue(any(item["type"] == "post" for item in payload))
+        self.assertTrue(any(item["type"] == "badge_awarded" for item in payload))
+        post_event = next(item for item in payload if item["type"] == "post")
+        self.assertEqual(post_event["payload"]["comment_count"], 0)
+        self.assertEqual(post_event["payload"]["topic"], self.topic.id)
+
+
+class ChallengeSerializerTests(TestCase):
+    def setUp(self):
+        self.user = get_user_model().objects.create_user("player", "player@example.com", "strongpass")
+        self.badge = Badge.objects.create(code="WEEKEND_SPOT", name="Weekend Warrior")
+        self.challenge = Challenge.objects.create(
+            code="WEEKEND",
+            title="Weekend Spotting Sprint",
+            description="Log five aircraft over the weekend",
+            start=date.today(),
+            end=date.today() + timedelta(days=2),
+            target_count=5,
+            badge_reward=self.badge,
+        )
+        self.progress = UserChallengeProgress.objects.create(user=self.user, challenge=self.challenge, progress=2)
+
+    def test_user_challenge_progress_serializer_enriches_fields(self):
+        data = UserChallengeProgressSerializer(self.progress).data
+        self.assertEqual(data["challenge_title"], self.challenge.title)
+        self.assertEqual(data["user_display"], self.user.username)

--- a/core/urls.py
+++ b/core/urls.py
@@ -1,8 +1,21 @@
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter
-from .views import (AirportViewSet, FrequencyViewSet, SpottingLocationViewSet, PhotoViewSet,
-                    AircraftViewSet, UserSeenViewSet, PostViewSet, CommentViewSet,
-                    BadgeViewSet, UserBadgeViewSet)
+from .views import (
+    AirportViewSet,
+    FrequencyViewSet,
+    SpottingLocationViewSet,
+    PhotoViewSet,
+    AircraftViewSet,
+    UserSeenViewSet,
+    PostViewSet,
+    CommentViewSet,
+    BadgeViewSet,
+    UserBadgeViewSet,
+    ForumTopicViewSet,
+    ChallengeViewSet,
+    UserChallengeProgressViewSet,
+    CommunityFeedView,
+)
 
 router = DefaultRouter()
 router.register(r"airports", AirportViewSet)
@@ -15,8 +28,12 @@ router.register(r"posts", PostViewSet)
 router.register(r"comments", CommentViewSet)
 router.register(r"badges", BadgeViewSet)
 router.register(r"userbadges", UserBadgeViewSet)
+router.register(r"topics", ForumTopicViewSet)
+router.register(r"challenges", ChallengeViewSet)
+router.register(r"challenge-progress", UserChallengeProgressViewSet)
 
 urlpatterns = [
     path("", include(router.urls)),
+    path("community/feed/", CommunityFeedView.as_view(), name="community-feed"),
 ]
 


### PR DESCRIPTION
## Summary
- add forum topics and seasonal challenge models to support richer community features
- expose new API endpoints and serializers, including a combined community feed of posts and badge awards
- back new features with serializer enhancements and unit tests for the feed and challenge progress

## Testing
- not run (Django dependencies unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dd4b4344ec8324b5bf38f83d4344f1