### PR TITLE
Add SwiftUI iOS app

### DIFF
--- a/ios/PlaneSpotter/PlaneSpotter.xcodeproj/project.pbxproj
+++ b/ios/PlaneSpotter/PlaneSpotter.xcodeproj/project.pbxproj
@@ -1,0 +1,351 @@
+// !$*UTF8*$!
+{
+    archiveVersion = 1;
+    classes = {};
+    objectVersion = 55;
+    objects = {
+    3A5A40EBC16B56CAA9A1C1BF /* PlaneSpotterApp.swift in Sources */ = { isa = PBXBuildFile; fileRef = F2C1C00447315A6FA3FDD661 /* PlaneSpotterApp.swift */; };
+    B75C3FE1F2D258A39287054F /* ContentView.swift in Sources */ = { isa = PBXBuildFile; fileRef = 0BB4C62A97EA5BC0B2318CE6 /* ContentView.swift */; };
+    6BD086F395E9594883E2FA2B /* Airport.swift in Sources */ = { isa = PBXBuildFile; fileRef = EF37EA1A1F8E5F3596A917BE /* Airport.swift */; };
+    1421403612055BCFA2E0E9EC /* APIClient.swift in Sources */ = { isa = PBXBuildFile; fileRef = 2532A5C86B5D572B8E33B012 /* APIClient.swift */; };
+    02DD320406E85FEFBA224C10 /* AirportListViewModel.swift in Sources */ = { isa = PBXBuildFile; fileRef = B0E9DD5D5CF95460BE0F3A39 /* AirportListViewModel.swift */; };
+    32186F235AE6519B907413BF /* AirportDetailViewModel.swift in Sources */ = { isa = PBXBuildFile; fileRef = 6FDA9530B3FF5999BF3EDB2C /* AirportDetailViewModel.swift */; };
+    BF2A83B98D30532CB7835576 /* AirportListView.swift in Sources */ = { isa = PBXBuildFile; fileRef = 2793A622C23A54B9B1770EE1 /* AirportListView.swift */; };
+    7D58661ABE2F55D0800DDD6E /* AirportRowView.swift in Sources */ = { isa = PBXBuildFile; fileRef = F38AAFF55EA4591CB02EEA0E /* AirportRowView.swift */; };
+    3DDF64D63D1D517BA9DB4F19 /* AirportDetailView.swift in Sources */ = { isa = PBXBuildFile; fileRef = FE634B60639B5588B47CE3A1 /* AirportDetailView.swift */; };
+    4A8463233A8A517895138350 /* ResourceTagView.swift in Sources */ = { isa = PBXBuildFile; fileRef = 2D919A5171B95B958FC41B4F /* ResourceTagView.swift */; };
+    B741AD8CA58B5C4F96409673 /* PlaceholderView.swift in Sources */ = { isa = PBXBuildFile; fileRef = 7897B666E43758EB97F765E3 /* PlaceholderView.swift */; };
+    9805E27A31F753C8B085CA34 /* FrequencyGuideView.swift in Sources */ = { isa = PBXBuildFile; fileRef = DADF21BC74B85CB39F55B621 /* FrequencyGuideView.swift */; };
+    EF3B99279F345D1F9C58F9AA /* AirportMapView.swift in Sources */ = { isa = PBXBuildFile; fileRef = 975C11955D8D5A26B2BC3AC3 /* AirportMapView.swift */; };
+    D50C61EDD0D85C72A1A3BB2D /* LoadingView.swift in Sources */ = { isa = PBXBuildFile; fileRef = 287D4DA01F115ED8A457531A /* LoadingView.swift */; };
+    C3674712E8E058248D65130B /* ErrorView.swift in Sources */ = { isa = PBXBuildFile; fileRef = 4089724706095F379021B3A0 /* ErrorView.swift */; };
+    BAA43D424EAE5AE88F066513 /* AppEnvironment.swift in Sources */ = { isa = PBXBuildFile; fileRef = 7588B2FB879A58A5BD7E4634 /* AppEnvironment.swift */; };
+    2F9957ABC6A45A59BDC1C681 /* AppEnvironment+Preview.swift in Sources */ = { isa = PBXBuildFile; fileRef = ACDDFD01F8DF55E9BEA70894 /* AppEnvironment+Preview.swift */; };
+    EFE877B9A7BF5C8493A151A7 /* Assets.xcassets in Resources */ = { isa = PBXBuildFile; fileRef = C0A54AFA5FC55138A4D4A2F6 /* Assets.xcassets */; };
+    65643599E0995BF3984EEF2A /* Info.plist */ = { isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+    F2C1C00447315A6FA3FDD661 /* PlaneSpotterApp.swift */ = { isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaneSpotter/PlaneSpotterApp.swift; sourceTree = "<group>"; };
+    0BB4C62A97EA5BC0B2318CE6 /* ContentView.swift */ = { isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaneSpotter/ContentView.swift; sourceTree = "<group>"; };
+    EF37EA1A1F8E5F3596A917BE /* Airport.swift */ = { isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaneSpotter/Models/Airport.swift; sourceTree = "<group>"; };
+    2532A5C86B5D572B8E33B012 /* APIClient.swift */ = { isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaneSpotter/Networking/APIClient.swift; sourceTree = "<group>"; };
+    B0E9DD5D5CF95460BE0F3A39 /* AirportListViewModel.swift */ = { isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaneSpotter/ViewModels/AirportListViewModel.swift; sourceTree = "<group>"; };
+    6FDA9530B3FF5999BF3EDB2C /* AirportDetailViewModel.swift */ = { isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaneSpotter/ViewModels/AirportDetailViewModel.swift; sourceTree = "<group>"; };
+    2793A622C23A54B9B1770EE1 /* AirportListView.swift */ = { isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaneSpotter/Views/AirportListView.swift; sourceTree = "<group>"; };
+    F38AAFF55EA4591CB02EEA0E /* AirportRowView.swift */ = { isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaneSpotter/Views/AirportRowView.swift; sourceTree = "<group>"; };
+    FE634B60639B5588B47CE3A1 /* AirportDetailView.swift */ = { isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaneSpotter/Views/AirportDetailView.swift; sourceTree = "<group>"; };
+    2D919A5171B95B958FC41B4F /* ResourceTagView.swift */ = { isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaneSpotter/Views/ResourceTagView.swift; sourceTree = "<group>"; };
+    7897B666E43758EB97F765E3 /* PlaceholderView.swift */ = { isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaneSpotter/Views/PlaceholderView.swift; sourceTree = "<group>"; };
+    DADF21BC74B85CB39F55B621 /* FrequencyGuideView.swift */ = { isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaneSpotter/Views/FrequencyGuideView.swift; sourceTree = "<group>"; };
+    975C11955D8D5A26B2BC3AC3 /* AirportMapView.swift */ = { isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaneSpotter/Views/AirportMapView.swift; sourceTree = "<group>"; };
+    287D4DA01F115ED8A457531A /* LoadingView.swift */ = { isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaneSpotter/Components/LoadingView.swift; sourceTree = "<group>"; };
+    4089724706095F379021B3A0 /* ErrorView.swift */ = { isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaneSpotter/Components/ErrorView.swift; sourceTree = "<group>"; };
+    7588B2FB879A58A5BD7E4634 /* AppEnvironment.swift */ = { isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaneSpotter/Utilities/AppEnvironment.swift; sourceTree = "<group>"; };
+    ACDDFD01F8DF55E9BEA70894 /* AppEnvironment+Preview.swift */ = { isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaneSpotter/Utilities/AppEnvironment+Preview.swift; sourceTree = "<group>"; };
+    C0A54AFA5FC55138A4D4A2F6 /* Assets.xcassets */ = { isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = PlaneSpotter/Assets.xcassets; sourceTree = "<group>"; };
+    33D8A06D23175CCAA075A162 /* PlaneSpotter.app */ = { isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PlaneSpotter.app; sourceTree = BUILT_PRODUCTS_DIR; };
+    
+13B49D253AB1579AB747FE43 /* Components */ = {
+    isa = PBXGroup;
+    children = (
+        4089724706095F379021B3A0 /* ErrorView.swift */,
+        287D4DA01F115ED8A457531A /* LoadingView.swift */
+    );
+    path = Components;
+    sourceTree = "<group>";
+};
+
+    
+AA616EE50AC15C21A92CAC2D /* Models */ = {
+    isa = PBXGroup;
+    children = (
+        EF37EA1A1F8E5F3596A917BE /* Airport.swift */
+    );
+    path = Models;
+    sourceTree = "<group>";
+};
+
+    
+8CC85BA63B7F507486B888E5 /* Networking */ = {
+    isa = PBXGroup;
+    children = (
+        2532A5C86B5D572B8E33B012 /* APIClient.swift */
+    );
+    path = Networking;
+    sourceTree = "<group>";
+};
+
+    
+4EFB3B35C06859C9975C98D5 /* Utilities */ = {
+    isa = PBXGroup;
+    children = (
+        7588B2FB879A58A5BD7E4634 /* AppEnvironment.swift */,
+        ACDDFD01F8DF55E9BEA70894 /* AppEnvironment+Preview.swift */
+    );
+    path = Utilities;
+    sourceTree = "<group>";
+};
+
+    
+612276449B6851E2A7406D9D /* ViewModels */ = {
+    isa = PBXGroup;
+    children = (
+        B0E9DD5D5CF95460BE0F3A39 /* AirportListViewModel.swift */,
+        6FDA9530B3FF5999BF3EDB2C /* AirportDetailViewModel.swift */
+    );
+    path = ViewModels;
+    sourceTree = "<group>";
+};
+
+    
+32E4E15EBF9D52A38AC6C07D /* Views */ = {
+    isa = PBXGroup;
+    children = (
+        2793A622C23A54B9B1770EE1 /* AirportListView.swift */,
+        F38AAFF55EA4591CB02EEA0E /* AirportRowView.swift */,
+        FE634B60639B5588B47CE3A1 /* AirportDetailView.swift */,
+        2D919A5171B95B958FC41B4F /* ResourceTagView.swift */,
+        7897B666E43758EB97F765E3 /* PlaceholderView.swift */,
+        DADF21BC74B85CB39F55B621 /* FrequencyGuideView.swift */,
+        975C11955D8D5A26B2BC3AC3 /* AirportMapView.swift */
+    );
+    path = Views;
+    sourceTree = "<group>";
+};
+
+    
+0F8DD1F09E9A597196C9AB70 /* PlaneSpotter */ = {
+    isa = PBXGroup;
+    children = (
+        F2C1C00447315A6FA3FDD661 /* PlaneSpotterApp.swift */,
+        0BB4C62A97EA5BC0B2318CE6 /* ContentView.swift */,
+        13B49D253AB1579AB747FE43 /* Components */,
+        AA616EE50AC15C21A92CAC2D /* Models */,
+        8CC85BA63B7F507486B888E5 /* Networking */,
+        4EFB3B35C06859C9975C98D5 /* Utilities */,
+        612276449B6851E2A7406D9D /* ViewModels */,
+        32E4E15EBF9D52A38AC6C07D /* Views */,
+        C0A54AFA5FC55138A4D4A2F6 /* Assets.xcassets */,
+        65643599E0995BF3984EEF2A /* Info.plist */
+    );
+    path = PlaneSpotter;
+    sourceTree = "<group>";
+};
+
+    
+5F8C4730DFA95DEE87415D38 /* Products */ = {
+    isa = PBXGroup;
+    children = (
+        33D8A06D23175CCAA075A162 /* PlaneSpotter.app */
+    );
+    name = Products;
+    sourceTree = "<group>";
+};
+
+    
+45C3A64478D15A1BB7E279C0 = {
+    isa = PBXGroup;
+    children = (
+        0F8DD1F09E9A597196C9AB70 /* PlaneSpotter */,
+        5F8C4730DFA95DEE87415D38 /* Products */
+    );
+    sourceTree = "<group>";
+};
+
+    
+4D205C4C799E5A4F87082E05 /* Sources */ = {
+    isa = PBXSourcesBuildPhase;
+    buildActionMask = 2147483647;
+    files = (
+        3A5A40EBC16B56CAA9A1C1BF,
+        B75C3FE1F2D258A39287054F,
+        6BD086F395E9594883E2FA2B,
+        1421403612055BCFA2E0E9EC,
+        02DD320406E85FEFBA224C10,
+        32186F235AE6519B907413BF,
+        BF2A83B98D30532CB7835576,
+        7D58661ABE2F55D0800DDD6E,
+        3DDF64D63D1D517BA9DB4F19,
+        4A8463233A8A517895138350,
+        B741AD8CA58B5C4F96409673,
+        9805E27A31F753C8B085CA34,
+        EF3B99279F345D1F9C58F9AA,
+        D50C61EDD0D85C72A1A3BB2D,
+        C3674712E8E058248D65130B,
+        BAA43D424EAE5AE88F066513,
+        2F9957ABC6A45A59BDC1C681
+    );
+    runOnlyForDeploymentPostprocessing = 0;
+};
+
+    
+C7FD5529B5A550E98BFBE368 /* Frameworks */ = {
+    isa = PBXFrameworksBuildPhase;
+    buildActionMask = 2147483647;
+    files = (
+    );
+    runOnlyForDeploymentPostprocessing = 0;
+};
+
+    
+434197D49AB6596DA7710A01 /* Resources */ = {
+    isa = PBXResourcesBuildPhase;
+    buildActionMask = 2147483647;
+    files = (
+        EFE877B9A7BF5C8493A151A7
+    );
+    runOnlyForDeploymentPostprocessing = 0;
+};
+
+    
+F4CE289E12215AE7B0E326C7 /* PlaneSpotter */ = {
+    isa = PBXNativeTarget;
+    buildConfigurationList = A842DBCDF1685C9893C575CE /* Build configuration list for PBXNativeTarget "PlaneSpotter" */;
+    buildPhases = (
+        4D205C4C799E5A4F87082E05 /* Sources */,
+        C7FD5529B5A550E98BFBE368 /* Frameworks */,
+        434197D49AB6596DA7710A01 /* Resources */,
+    );
+    buildRules = (
+    );
+    dependencies = (
+    );
+    name = PlaneSpotter;
+    productName = PlaneSpotter;
+    productReference = 33D8A06D23175CCAA075A162 /* PlaneSpotter.app */;
+    productType = "com.apple.product-type.application";
+};
+
+    
+A400E5D704095A8190503991 /* Project object */ = {
+    isa = PBXProject;
+    attributes = {
+        LastSwiftUpdateCheck = 1520;
+        LastUpgradeCheck = 1520;
+        TargetAttributes = {
+            F4CE289E12215AE7B0E326C7 = {
+                DevelopmentTeam = "";
+                ProvisioningStyle = Manual;
+            };
+        };
+    };
+    buildConfigurationList = 285D8075BDB052768E52F298 /* Build configuration list for PBXProject "PlaneSpotter" */;
+    compatibilityVersion = "Xcode 14.0";
+    developmentRegion = en;
+    hasScannedForEncodings = 0;
+    knownRegions = (
+        en,
+        Base,
+    );
+    mainGroup = 45C3A64478D15A1BB7E279C0;
+    productRefGroup = 5F8C4730DFA95DEE87415D38 /* Products */;
+    projectDirPath = "";
+    projectRoot = "";
+    targets = (
+        F4CE289E12215AE7B0E326C7 /* PlaneSpotter */,
+    );
+};
+
+    
+1A53D24CE6BE5EF9BAA534E7 /* Debug */ = {
+    isa = XCBuildConfiguration;
+    buildSettings = {
+        CLANG_ANALYZER_NONNULL = YES;
+        ENABLE_TESTABILITY = YES;
+        GCC_C_LANGUAGE_STANDARD = gnu17;
+        GCC_NO_COMMON_BLOCKS = YES;
+        GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+        GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+        GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+        GCC_WARN_UNUSED_FUNCTION = YES;
+        GCC_WARN_UNUSED_VARIABLE = YES;
+        IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+        MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+        ONLY_ACTIVE_ARCH = YES;
+        SDKROOT = iphoneos;
+    };
+    name = Debug;
+};
+
+    
+C7725D25863F58ACB190CBAF /* Release */ = {
+    isa = XCBuildConfiguration;
+    buildSettings = {
+        CLANG_ANALYZER_NONNULL = YES;
+        GCC_C_LANGUAGE_STANDARD = gnu17;
+        GCC_NO_COMMON_BLOCKS = YES;
+        GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+        GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+        GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+        GCC_WARN_UNUSED_FUNCTION = YES;
+        GCC_WARN_UNUSED_VARIABLE = YES;
+        IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+        MTL_ENABLE_DEBUG_INFO = NO;
+        SDKROOT = iphoneos;
+    };
+    name = Release;
+};
+
+    
+285D8075BDB052768E52F298 /* Build configuration list for PBXProject "PlaneSpotter" */ = {
+    isa = XCConfigurationList;
+    buildConfigurations = (
+        1A53D24CE6BE5EF9BAA534E7 /* Debug */,
+        C7725D25863F58ACB190CBAF /* Release */,
+    );
+    defaultConfigurationIsVisible = 0;
+    defaultConfigurationName = Release;
+};
+
+    
+498877A5735F57F7982B845F /* Debug */ = {
+    isa = XCBuildConfiguration;
+    buildSettings = {
+        ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+        CODE_SIGN_STYLE = Manual;
+        DEVELOPMENT_TEAM = "";
+        GENERATE_INFOPLIST_FILE = NO;
+        INFOPLIST_FILE = PlaneSpotter/Info.plist;
+        IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+        LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/Frameworks");
+        PRODUCT_BUNDLE_IDENTIFIER = com.example.Planespotter;
+        PRODUCT_NAME = "$(TARGET_NAME)";
+        SWIFT_EMIT_LOC_STRINGS = YES;
+        SWIFT_VERSION = 5.9;
+        TARGETED_DEVICE_FAMILY = "1,2";
+    };
+    name = Debug;
+};
+
+    
+A7D2CAA6B1965DA199E900B4 /* Release */ = {
+    isa = XCBuildConfiguration;
+    buildSettings = {
+        ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+        CODE_SIGN_STYLE = Manual;
+        DEVELOPMENT_TEAM = "";
+        GENERATE_INFOPLIST_FILE = NO;
+        INFOPLIST_FILE = PlaneSpotter/Info.plist;
+        IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+        LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/Frameworks");
+        PRODUCT_BUNDLE_IDENTIFIER = com.example.Planespotter;
+        PRODUCT_NAME = "$(TARGET_NAME)";
+        SWIFT_EMIT_LOC_STRINGS = YES;
+        SWIFT_VERSION = 5.9;
+        TARGETED_DEVICE_FAMILY = "1,2";
+    };
+    name = Release;
+};
+
+    
+A842DBCDF1685C9893C575CE /* Build configuration list for PBXNativeTarget "PlaneSpotter" */ = {
+    isa = XCConfigurationList;
+    buildConfigurations = (
+        498877A5735F57F7982B845F /* Debug */,
+        A7D2CAA6B1965DA199E900B4 /* Release */,
+    );
+    defaultConfigurationIsVisible = 0;
+    defaultConfigurationName = Release;
+};
+
+    };
+    rootObject = A400E5D704095A8190503991 /* Project object */;
+}

--- a/ios/PlaneSpotter/PlaneSpotter/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/ios/PlaneSpotter/PlaneSpotter/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.949",
+          "green" : "0.784",
+          "red" : "0.220"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/PlaneSpotter/PlaneSpotter/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/ios/PlaneSpotter/PlaneSpotter/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,18 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/PlaneSpotter/PlaneSpotter/Assets.xcassets/Contents.json
+++ b/ios/PlaneSpotter/PlaneSpotter/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/PlaneSpotter/PlaneSpotter/Components/ErrorView.swift
+++ b/ios/PlaneSpotter/PlaneSpotter/Components/ErrorView.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+struct ErrorView: View {
+    let title: String
+    let message: String
+    let retry: (() -> Void)?
+
+    init(title: String = "Something went wrong", message: String, retry: (() -> Void)? = nil) {
+        self.title = title
+        self.message = message
+        self.retry = retry
+    }
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.system(size: 44))
+                .foregroundStyle(.orange)
+            VStack(spacing: 6) {
+                Text(title)
+                    .font(.headline)
+                Text(message)
+                    .font(.subheadline)
+                    .multilineTextAlignment(.center)
+                    .foregroundStyle(.secondary)
+            }
+            if let retry {
+                Button(action: retry) {
+                    Label("Try Again", systemImage: "arrow.clockwise")
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 10)
+                        .background(Color.accentColor.opacity(0.12), in: Capsule())
+                }
+            }
+        }
+        .padding()
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}

--- a/ios/PlaneSpotter/PlaneSpotter/Components/LoadingView.swift
+++ b/ios/PlaneSpotter/PlaneSpotter/Components/LoadingView.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+struct LoadingView: View {
+    var body: some View {
+        VStack(spacing: 12) {
+            ProgressView()
+                .progressViewStyle(.circular)
+            Text("Loading…")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding()
+    }
+}

--- a/ios/PlaneSpotter/PlaneSpotter/ContentView.swift
+++ b/ios/PlaneSpotter/PlaneSpotter/ContentView.swift
@@ -1,0 +1,100 @@
+import SwiftUI
+
+struct HomeSection: Identifiable {
+    enum Destination {
+        case airports
+        case frequencyGuide
+        case map
+        case live
+        case logbook
+        case community
+    }
+
+    let id = UUID()
+    let title: String
+    let subtitle: String
+    let systemImage: String
+    let destination: Destination
+    let accent: Color
+}
+
+struct ContentView: View {
+    @EnvironmentObject private var environment: AppEnvironment
+
+    private var sections: [HomeSection] {
+        [
+            HomeSection(title: "Airports", subtitle: "Spotting locations, reviews & photos", systemImage: "airplane.departure", destination: .airports, accent: .blue),
+            HomeSection(title: "Frequencies", subtitle: "ATC communication primer", systemImage: "dot.radiowaves.left.and.right", destination: .frequencyGuide, accent: .purple),
+            HomeSection(title: "Maps", subtitle: "Visualise airfields on a map", systemImage: "map", destination: .map, accent: .green),
+            HomeSection(title: "Live ADS-B", subtitle: "Track aircraft near favourite airports", systemImage: "radar", destination: .live, accent: .orange),
+            HomeSection(title: "Logbook", subtitle: "Record aircraft you’ve spotted", systemImage: "note.text", destination: .logbook, accent: .teal),
+            HomeSection(title: "Community", subtitle: "Forum, chat & badges", systemImage: "person.3", destination: .community, accent: .pink)
+        ]
+    }
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 24) {
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text("Plane Spotter")
+                            .font(.largeTitle.bold())
+                        Text("Your complete plane spotting companion — explore airports, check frequencies, log aircraft, and connect with the spotting community.")
+                            .foregroundStyle(.secondary)
+                    }
+                    LazyVGrid(columns: [GridItem(.adaptive(minimum: 160), spacing: 16)], spacing: 16) {
+                        ForEach(sections) { section in
+                            NavigationLink(value: section.destination) {
+                                VStack(alignment: .leading, spacing: 12) {
+                                    Image(systemName: section.systemImage)
+                                        .font(.largeTitle)
+                                        .foregroundStyle(section.accent)
+                                        .frame(maxWidth: .infinity, alignment: .leading)
+                                    VStack(alignment: .leading, spacing: 6) {
+                                        Text(section.title)
+                                            .font(.headline)
+                                        Text(section.subtitle)
+                                            .font(.subheadline)
+                                            .foregroundStyle(.secondary)
+                                    }
+                                    Spacer(minLength: 0)
+                                }
+                                .padding()
+                                .frame(maxWidth: .infinity, minHeight: 150)
+                                .background(.background, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+                                .shadow(color: .black.opacity(0.08), radius: 10, x: 0, y: 4)
+                            }
+                        }
+                    }
+                }
+                .padding()
+            }
+            .background(Color(.systemGroupedBackground))
+            .navigationDestination(for: HomeSection.Destination.self) { destination in
+                switch destination {
+                case .airports:
+                    AirportListView()
+                        .environmentObject(environment)
+                case .frequencyGuide:
+                    FrequencyGuideView()
+                case .map:
+                    AirportMapView()
+                        .environmentObject(environment)
+                case .live:
+                    PlaceholderView(title: "Live ADS-B", message: "Integration with a real-time ADS-B provider can surface nearby aircraft. Add your API credentials and rendering logic here.")
+                case .logbook:
+                    PlaceholderView(title: "Logbook", message: "Connect to the /api/seen/ endpoint to sync spotted aircraft and maintain a personal logbook.")
+                case .community:
+                    PlaceholderView(title: "Community", message: "Hook into the posts, comments, and badges endpoints to deliver community features on iOS.")
+                }
+            }
+        }
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+            .environmentObject(AppEnvironment(bundle: .main))
+    }
+}

--- a/ios/PlaneSpotter/PlaneSpotter/Info.plist
+++ b/ios/PlaneSpotter/PlaneSpotter/Info.plist
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>$(DEVELOPMENT_LANGUAGE)</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>$(PRODUCT_NAME)</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>LSRequiresIPhoneOS</key>
+    <true/>
+    <key>UIApplicationSceneManifest</key>
+    <dict>
+        <key>UIApplicationSupportsMultipleScenes</key>
+        <false/>
+        <key>UISceneConfigurations</key>
+        <dict>
+            <key>UIWindowSceneSessionRoleApplication</key>
+            <array>
+                <dict>
+                    <key>UISceneConfigurationName</key>
+                    <string>Default Configuration</string>
+                    <key>UISceneDelegateClassName</key>
+                    <string></string>
+                    <key>UISceneStoryboardFile</key>
+                    <string></string>
+                </dict>
+            </array>
+        </dict>
+    </dict>
+    <key>UILaunchScreen</key>
+    <dict/>
+    <key>UIRequiredDeviceCapabilities</key>
+    <array>
+        <string>arm64</string>
+    </array>
+    <key>UISupportedInterfaceOrientations</key>
+    <array>
+        <string>UIInterfaceOrientationPortrait</string>
+        <string>UIInterfaceOrientationLandscapeLeft</string>
+        <string>UIInterfaceOrientationLandscapeRight</string>
+    </array>
+    <key>API_BASE_URL</key>
+    <string>http://localhost:8000/api</string>
+</dict>
+</plist>

--- a/ios/PlaneSpotter/PlaneSpotter/Models/Airport.swift
+++ b/ios/PlaneSpotter/PlaneSpotter/Models/Airport.swift
@@ -1,0 +1,66 @@
+import Foundation
+import CoreLocation
+
+struct Airport: Identifiable, Decodable, Equatable {
+    struct Frequency: Identifiable, Decodable, Equatable {
+        let id: Int
+        let service: String
+        let mhz: String
+        let description: String?
+
+        var formattedFrequency: String {
+            if let value = Double(mhz) {
+                return String(format: "%.3f MHz", value)
+            }
+            return "\(mhz) MHz"
+        }
+    }
+
+    struct SpottingLocation: Identifiable, Decodable, Equatable {
+        let id: Int
+        let title: String
+        let description: String?
+        let tips: String?
+        let lat: Double?
+        let lon: Double?
+
+        var coordinate: CLLocationCoordinate2D? {
+            guard let lat, let lon else { return nil }
+            return CLLocationCoordinate2D(latitude: lat, longitude: lon)
+        }
+    }
+
+    struct Resource: Identifiable, Decodable, Equatable {
+        let id: Int
+        let title: String
+        let url: URL
+        let category: String
+        let description: String?
+    }
+
+    let id: Int
+    let icao: String
+    let iata: String?
+    let name: String
+    let city: String?
+    let country: String
+    let lat: Double?
+    let lon: Double?
+    let frequencies: [Frequency]
+    let spots: [SpottingLocation]
+    let resources: [Resource]
+
+    var coordinate: CLLocationCoordinate2D? {
+        guard let lat, let lon else { return nil }
+        return CLLocationCoordinate2D(latitude: lat, longitude: lon)
+    }
+
+    var displayName: String {
+        "\(icao) · \(name)"
+    }
+
+    var subtitle: String {
+        let location = [city, country].compactMap { $0?.isEmpty == false ? $0 : nil }.joined(separator: ", ")
+        return location.isEmpty ? "" : location
+    }
+}

--- a/ios/PlaneSpotter/PlaneSpotter/Networking/APIClient.swift
+++ b/ios/PlaneSpotter/PlaneSpotter/Networking/APIClient.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+struct APIClient {
+    struct APIError: LocalizedError {
+        enum ErrorType {
+            case invalidURL
+            case transport(Error)
+            case decoding(Error)
+            case server(status: Int)
+        }
+
+        let type: ErrorType
+
+        var errorDescription: String? {
+            switch type {
+            case .invalidURL:
+                return "The request URL was invalid."
+            case let .transport(error):
+                return error.localizedDescription
+            case let .decoding(error):
+                return "Failed to decode response: \(error.localizedDescription)"
+            case let .server(status):
+                return "Server returned status code \(status)."
+            }
+        }
+    }
+
+    var baseURL: URL
+    var session: URLSession
+
+    init(baseURL: URL, session: URLSession = .shared) {
+        self.baseURL = baseURL
+        self.session = session
+    }
+
+    func get<T: Decodable>(_ path: String, queryItems: [URLQueryItem] = []) async throws -> T {
+        guard var components = URLComponents(url: baseURL.appendingPathComponent(path), resolvingAgainstBaseURL: false) else {
+            throw APIError(type: .invalidURL)
+        }
+        if !queryItems.isEmpty {
+            components.queryItems = queryItems
+        }
+        guard let url = components.url else {
+            throw APIError(type: .invalidURL)
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        do {
+            let (data, response) = try await session.data(for: request)
+            if let httpResponse = response as? HTTPURLResponse, !(200...299).contains(httpResponse.statusCode) {
+                throw APIError(type: .server(status: httpResponse.statusCode))
+            }
+            let decoder = JSONDecoder()
+            decoder.keyDecodingStrategy = .convertFromSnakeCase
+            decoder.dateDecodingStrategy = .iso8601
+            return try decoder.decode(T.self, from: data)
+        } catch let error as APIError {
+            throw error
+        } catch let error as DecodingError {
+            throw APIError(type: .decoding(error))
+        } catch {
+            throw APIError(type: .transport(error))
+        }
+    }
+}

--- a/ios/PlaneSpotter/PlaneSpotter/PlaneSpotterApp.swift
+++ b/ios/PlaneSpotter/PlaneSpotter/PlaneSpotterApp.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+@main
+struct PlaneSpotterApp: App {
+    @StateObject private var environment = AppEnvironment()
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environmentObject(environment)
+        }
+    }
+}

--- a/ios/PlaneSpotter/PlaneSpotter/Utilities/AppEnvironment+Preview.swift
+++ b/ios/PlaneSpotter/PlaneSpotter/Utilities/AppEnvironment+Preview.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+extension AppEnvironment {
+    static var preview: AppEnvironment {
+        AppEnvironment(bundle: .main, session: .shared)
+    }
+}

--- a/ios/PlaneSpotter/PlaneSpotter/Utilities/AppEnvironment.swift
+++ b/ios/PlaneSpotter/PlaneSpotter/Utilities/AppEnvironment.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+@MainActor
+final class AppEnvironment: ObservableObject {
+    let apiClient: APIClient
+
+    init(bundle: Bundle = .main, session: URLSession = .shared) {
+        let defaultURL = URL(string: "http://localhost:8000/api")!
+        if let baseURLString = bundle.object(forInfoDictionaryKey: "API_BASE_URL") as? String,
+           let parsedURL = URL(string: baseURLString) {
+            self.apiClient = APIClient(baseURL: parsedURL, session: session)
+        } else {
+            self.apiClient = APIClient(baseURL: defaultURL, session: session)
+        }
+    }
+}

--- a/ios/PlaneSpotter/PlaneSpotter/ViewModels/AirportDetailViewModel.swift
+++ b/ios/PlaneSpotter/PlaneSpotter/ViewModels/AirportDetailViewModel.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+@MainActor
+final class AirportDetailViewModel: ObservableObject {
+    enum State: Equatable {
+        case idle
+        case loading
+        case loaded(Airport)
+        case failed(String)
+    }
+
+    @Published private(set) var state: State = .idle
+
+    private var apiClient: APIClient
+    private let airportID: Int
+
+    init(airportID: Int, apiClient: APIClient) {
+        self.airportID = airportID
+        self.apiClient = apiClient
+    }
+
+    func updateAPIClient(_ apiClient: APIClient) {
+        self.apiClient = apiClient
+    }
+
+    func load() async {
+        state = .loading
+        do {
+            let airport: Airport = try await apiClient.get("airports/\(airportID)/")
+            state = .loaded(airport)
+        } catch {
+            if let error = error as? APIClient.APIError {
+                state = .failed(error.localizedDescription)
+            } else {
+                state = .failed(error.localizedDescription)
+            }
+        }
+    }
+}

--- a/ios/PlaneSpotter/PlaneSpotter/ViewModels/AirportListViewModel.swift
+++ b/ios/PlaneSpotter/PlaneSpotter/ViewModels/AirportListViewModel.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+@MainActor
+final class AirportListViewModel: ObservableObject {
+    enum State: Equatable {
+        case idle
+        case loading
+        case loaded([Airport])
+        case failed(String)
+    }
+
+    @Published private(set) var state: State = .idle
+
+    private var apiClient: APIClient
+
+    init(apiClient: APIClient) {
+        self.apiClient = apiClient
+    }
+
+    func updateAPIClient(_ apiClient: APIClient) {
+        self.apiClient = apiClient
+    }
+
+    func loadAirports() async {
+        state = .loading
+        do {
+            let airports: [Airport] = try await apiClient.get("airports/")
+            state = .loaded(airports.sorted(by: { $0.icao < $1.icao }))
+        } catch {
+            if let error = error as? APIClient.APIError {
+                state = .failed(error.localizedDescription)
+            } else {
+                state = .failed(error.localizedDescription)
+            }
+        }
+    }
+}

--- a/ios/PlaneSpotter/PlaneSpotter/Views/AirportDetailView.swift
+++ b/ios/PlaneSpotter/PlaneSpotter/Views/AirportDetailView.swift
@@ -1,0 +1,189 @@
+import SwiftUI
+import MapKit
+
+struct AirportDetailView: View {
+    @EnvironmentObject private var environment: AppEnvironment
+    @StateObject private var viewModel: AirportDetailViewModel
+
+    init(airportID: Int) {
+        _viewModel = StateObject(wrappedValue: AirportDetailViewModel(airportID: airportID, apiClient: AppEnvironment.preview.apiClient))
+    }
+
+    var body: some View {
+        content
+            .navigationBarTitleDisplayMode(.inline)
+            .task {
+                viewModel.updateAPIClient(environment.apiClient)
+                if case .idle = viewModel.state {
+                    await viewModel.load()
+                }
+            }
+            .refreshable {
+                viewModel.updateAPIClient(environment.apiClient)
+                await viewModel.load()
+            }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch viewModel.state {
+        case .idle, .loading:
+            LoadingView()
+        case let .failed(message):
+            ErrorView(message: message) {
+                Task {
+                    viewModel.updateAPIClient(environment.apiClient)
+                    await viewModel.load()
+                }
+            }
+        case let .loaded(airport):
+            ScrollView {
+                VStack(alignment: .leading, spacing: 24) {
+                    header(for: airport)
+                    if let coordinate = airport.coordinate {
+                        Map(initialPosition: .region(MKCoordinateRegion(center: coordinate, span: MKCoordinateSpan(latitudeDelta: 0.05, longitudeDelta: 0.05)))) {
+                            Marker(airport.icao, coordinate: coordinate)
+                        }
+                        .frame(height: 220)
+                        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+                    }
+                    frequenciesSection(for: airport)
+                    spotsSection(for: airport)
+                    resourcesSection(for: airport)
+                }
+                .padding()
+            }
+            .background(Color(.systemGroupedBackground))
+            .navigationTitle(airport.icao)
+        }
+    }
+
+    private func header(for airport: Airport) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(airport.displayName)
+                .font(.title.bold())
+            if !airport.subtitle.isEmpty {
+                Text(airport.subtitle)
+                    .font(.headline)
+                    .foregroundStyle(.secondary)
+            }
+            if let coordinate = airport.coordinate {
+                Text(String(format: "Lat %.4f · Lon %.4f", coordinate.latitude, coordinate.longitude))
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func frequenciesSection(for airport: Airport) -> some View {
+        Section {
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Frequencies")
+                    .font(.title3.bold())
+                if airport.frequencies.isEmpty {
+                    Text("No frequencies have been added yet.")
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(airport.frequencies) { frequency in
+                        VStack(alignment: .leading, spacing: 6) {
+                            Text(frequency.service)
+                                .font(.headline)
+                            Text(frequency.formattedFrequency)
+                                .font(.subheadline.monospaced())
+                                .foregroundStyle(.blue)
+                            if let description = frequency.description, !description.isEmpty {
+                                Text(description)
+                                    .font(.footnote)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        .padding()
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(.background, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+                        .shadow(color: .black.opacity(0.05), radius: 8, x: 0, y: 4)
+                    }
+                }
+            }
+        }
+    }
+
+    private func spotsSection(for airport: Airport) -> some View {
+        Section {
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Spotting Locations")
+                    .font(.title3.bold())
+                if airport.spots.isEmpty {
+                    Text("No spotting locations recorded yet. Be the first to add one!")
+                        .foregroundStyle(.secondary)
+                } else {
+                    VStack(spacing: 12) {
+                        ForEach(airport.spots) { spot in
+                            VStack(alignment: .leading, spacing: 8) {
+                                Text(spot.title)
+                                    .font(.headline)
+                                if let description = spot.description, !description.isEmpty {
+                                    Text(description)
+                                        .font(.body)
+                                }
+                                if let coordinate = spot.coordinate {
+                                    Text(String(format: "Lat %.4f · Lon %.4f", coordinate.latitude, coordinate.longitude))
+                                        .font(.footnote)
+                                        .foregroundStyle(.secondary)
+                                }
+                                if let tips = spot.tips, !tips.isEmpty {
+                                    Text(tips)
+                                        .font(.footnote)
+                                        .foregroundStyle(.blue)
+                                        .padding(10)
+                                        .background(Color.blue.opacity(0.1), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+                                }
+                            }
+                            .padding()
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .background(.background, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+                            .shadow(color: .black.opacity(0.05), radius: 8, x: 0, y: 4)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private func resourcesSection(for airport: Airport) -> some View {
+        Section {
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Resources")
+                    .font(.title3.bold())
+                if airport.resources.isEmpty {
+                    Text("No resources listed yet.")
+                        .foregroundStyle(.secondary)
+                } else {
+                    VStack(spacing: 12) {
+                        ForEach(airport.resources) { resource in
+                            VStack(alignment: .leading, spacing: 8) {
+                                HStack {
+                                    VStack(alignment: .leading, spacing: 4) {
+                                        Link(resource.title, destination: resource.url)
+                                            .font(.headline)
+                                        if let description = resource.description, !description.isEmpty {
+                                            Text(description)
+                                                .font(.footnote)
+                                                .foregroundStyle(.secondary)
+                                        }
+                                    }
+                                    Spacer()
+                                    ResourceTagView(category: resource.category)
+                                }
+                            }
+                            .padding()
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .background(.background, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+                            .shadow(color: .black.opacity(0.05), radius: 8, x: 0, y: 4)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ios/PlaneSpotter/PlaneSpotter/Views/AirportListView.swift
+++ b/ios/PlaneSpotter/PlaneSpotter/Views/AirportListView.swift
@@ -1,0 +1,65 @@
+import SwiftUI
+
+struct AirportListView: View {
+    @EnvironmentObject private var environment: AppEnvironment
+    @StateObject private var viewModel: AirportListViewModel
+    @State private var searchText = ""
+
+    init() {
+        _viewModel = StateObject(wrappedValue: AirportListViewModel(apiClient: AppEnvironment.preview.apiClient))
+    }
+
+    var body: some View {
+        content
+            .navigationTitle("Airports")
+            .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .always))
+            .task {
+                viewModel.updateAPIClient(environment.apiClient)
+                if case .idle = viewModel.state {
+                    await viewModel.loadAirports()
+                }
+            }
+            .refreshable {
+                viewModel.updateAPIClient(environment.apiClient)
+                await viewModel.loadAirports()
+            }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch viewModel.state {
+        case .idle, .loading:
+            LoadingView()
+        case let .failed(message):
+            ErrorView(message: message) {
+                Task {
+                    viewModel.updateAPIClient(environment.apiClient)
+                    await viewModel.loadAirports()
+                }
+            }
+        case let .loaded(airports):
+            let filtered = airports.filter { airport in
+                searchText.isEmpty ? true : airportMatchesSearch(airport)
+            }
+            List(filtered) { airport in
+                NavigationLink(value: airport.id) {
+                    AirportRowView(airport: airport)
+                }
+            }
+            .listStyle(.insetGrouped)
+            .navigationDestination(for: Int.self) { id in
+                AirportDetailView(airportID: id)
+                    .environmentObject(environment)
+            }
+        }
+    }
+
+    private func airportMatchesSearch(_ airport: Airport) -> Bool {
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty else { return true }
+        let haystack = [airport.icao, airport.iata ?? "", airport.name, airport.city ?? "", airport.country]
+            .joined(separator: " ")
+            .lowercased()
+        return haystack.contains(query.lowercased())
+    }
+}

--- a/ios/PlaneSpotter/PlaneSpotter/Views/AirportMapView.swift
+++ b/ios/PlaneSpotter/PlaneSpotter/Views/AirportMapView.swift
@@ -1,0 +1,98 @@
+import SwiftUI
+import MapKit
+
+private struct AnnotatedAirport: Identifiable {
+    let id: Int
+    let airport: Airport
+    let coordinate: CLLocationCoordinate2D
+}
+
+struct AirportMapView: View {
+    @EnvironmentObject private var environment: AppEnvironment
+    @StateObject private var listViewModel: AirportListViewModel
+    @State private var position: MapCameraPosition = .automatic
+
+    init() {
+        _listViewModel = StateObject(wrappedValue: AirportListViewModel(apiClient: AppEnvironment.preview.apiClient))
+    }
+
+    var body: some View {
+        content
+            .navigationTitle("Maps")
+            .task {
+                listViewModel.updateAPIClient(environment.apiClient)
+                if case .idle = listViewModel.state {
+                    await listViewModel.loadAirports()
+                }
+            }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch listViewModel.state {
+        case .idle, .loading:
+            LoadingView()
+        case let .failed(message):
+            ErrorView(message: message) {
+                Task {
+                    listViewModel.updateAPIClient(environment.apiClient)
+                    await listViewModel.loadAirports()
+                }
+            }
+        case let .loaded(airports):
+            let annotatedAirports = airports.compactMap { airport -> AnnotatedAirport? in
+                guard let coordinate = airport.coordinate else { return nil }
+                return AnnotatedAirport(id: airport.id, airport: airport, coordinate: coordinate)
+            }
+            Map(position: $position, interactionModes: .all) {
+                ForEach(annotatedAirports) { item in
+                    Annotation(item.airport.icao, coordinate: item.coordinate) {
+                        VStack(spacing: 4) {
+                            Text(item.airport.icao)
+                                .font(.caption.bold())
+                                .padding(6)
+                                .background(.ultraThinMaterial, in: Capsule())
+                            Image(systemName: "airplane")
+                                .padding(6)
+                                .background(Color.accentColor, in: Circle())
+                                .foregroundStyle(.white)
+                        }
+                    }
+                }
+            }
+            .mapStyle(.standard(elevation: .realistic))
+            .overlay(alignment: .bottom) {
+                if !airports.isEmpty {
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack(spacing: 12) {
+                            ForEach(airports) { airport in
+                                Button {
+                                    if let coordinate = airport.coordinate {
+                                        withAnimation(.easeInOut) {
+                                            position = .region(MKCoordinateRegion(center: coordinate, span: MKCoordinateSpan(latitudeDelta: 0.1, longitudeDelta: 0.1)))
+                                        }
+                                    }
+                                } label: {
+                                    VStack(alignment: .leading, spacing: 4) {
+                                        Text(airport.icao)
+                                            .font(.headline)
+                                        Text(airport.name)
+                                            .font(.caption)
+                                            .foregroundStyle(.secondary)
+                                    }
+                                    .padding()
+                                    .background(.background, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+                                    .shadow(color: .black.opacity(0.08), radius: 6, x: 0, y: 3)
+                                }
+                                .buttonStyle(.plain)
+                            }
+                        }
+                        .padding(.horizontal)
+                    }
+                    .padding(.vertical, 8)
+                    .background(.thinMaterial)
+                }
+            }
+        }
+    }
+}

--- a/ios/PlaneSpotter/PlaneSpotter/Views/AirportRowView.swift
+++ b/ios/PlaneSpotter/PlaneSpotter/Views/AirportRowView.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+
+struct AirportRowView: View {
+    let airport: Airport
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Text(airport.icao)
+                    .font(.headline)
+                if let iata = airport.iata, !iata.isEmpty {
+                    Text(iata)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+            }
+            Text(airport.name)
+                .font(.subheadline.weight(.medium))
+            if !airport.subtitle.isEmpty {
+                Text(airport.subtitle)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(.vertical, 6)
+    }
+}
+
+struct AirportRowView_Previews: PreviewProvider {
+    static var previews: some View {
+        List {
+            AirportRowView(airport: Airport(
+                id: 1,
+                icao: "EGLL",
+                iata: "LHR",
+                name: "Heathrow Airport",
+                city: "London",
+                country: "United Kingdom",
+                lat: 51.4700,
+                lon: -0.4543,
+                frequencies: [],
+                spots: [],
+                resources: []
+            ))
+        }
+    }
+}

--- a/ios/PlaneSpotter/PlaneSpotter/Views/FrequencyGuideView.swift
+++ b/ios/PlaneSpotter/PlaneSpotter/Views/FrequencyGuideView.swift
@@ -1,0 +1,95 @@
+import SwiftUI
+
+struct FrequencyGuideView: View {
+    struct Methodology: Identifiable {
+        let id = UUID()
+        let title: String
+        let description: String
+    }
+
+    struct Exchange: Identifiable {
+        let id = UUID()
+        let call: String
+        let meaning: String
+    }
+
+    private let methodology: [Methodology] = [
+        Methodology(title: "Tower Operations", description: "Tower controllers manage aircraft in the immediate vicinity of the airport—typically the runway and traffic pattern. They issue takeoff and landing clearances, sequencing departures and arrivals to maintain safe separation."),
+        Methodology(title: "Ground Control", description: "Ground handles aircraft and vehicles on taxiways and ramps. Controllers provide taxi clearances, monitor surface movement, and ensure conflicts are avoided before aircraft reach the runway."),
+        Methodology(title: "Approach & Departure", description: "Approach and departure controllers transition aircraft between en-route airspace and the terminal area. They coordinate climbs, descents, and vectors to efficiently sequence flights around congested airspace."),
+        Methodology(title: "Center / En-Route", description: "Air Route Traffic Control Centers oversee aircraft cruising between airports. They manage large sectors of airspace, coordinating altitude changes and hand-offs between adjacent sectors and facilities.")
+    ]
+
+    private let exchanges: [Exchange] = [
+        Exchange(call: "ATIS", meaning: "Automatic Terminal Information Service broadcasts current weather, runways in use, and airport notices. Pilots state the letter code (e.g., 'Information Bravo') to confirm receipt when contacting controllers."),
+        Exchange(call: "Clearance Delivery", meaning: "Provides IFR route clearance before taxi. Typical read-back includes the cleared route, initial altitude, departure frequency, and transponder code."),
+        Exchange(call: "Taxi / Ground", meaning: "Ground control gives taxi instructions such as 'Taxi to Runway 27 via Alpha, hold short Runway 22'. Pilots must read back hold short instructions and runway assignments to confirm compliance."),
+        Exchange(call: "Takeoff Clearance", meaning: "When tower issues 'Cleared for takeoff', the aircraft may enter the runway and depart. Pilots read back the clearance to acknowledge and begin the roll when safe."),
+        Exchange(call: "Landing Clearance", meaning: "Tower communicates 'Cleared to land' once the runway is verified clear. Pilots acknowledge and continue final approach, reporting if unable or executing a go-around as necessary."),
+        Exchange(call: "Handoff / Frequency Change", meaning: "Controllers coordinate handoffs between facilities. A call like 'Contact Departure on 118.5' prompts pilots to switch frequencies, check in, and continue on the new controller's instructions.")
+    ]
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("ATC Communication Guide")
+                        .font(.largeTitle.bold())
+                    Text("Understand how Air Traffic Control orchestrates safe aircraft movement and what common radio telephony calls mean before you tune in.")
+                        .font(.body)
+                        .foregroundStyle(.secondary)
+                }
+
+                VStack(alignment: .leading, spacing: 16) {
+                    Text("ATC Methodology")
+                        .font(.title3.bold())
+                    Text("Controllers coordinate flights through a series of specialised positions. Each role focuses on a specific phase of flight, ensuring clear responsibilities and consistent separation standards.")
+                        .foregroundStyle(.secondary)
+                    ForEach(methodology) { item in
+                        VStack(alignment: .leading, spacing: 6) {
+                            Text(item.title)
+                                .font(.headline)
+                            Text(item.description)
+                                .font(.body)
+                                .foregroundStyle(.secondary)
+                        }
+                        .padding()
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(.background, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+                        .shadow(color: .black.opacity(0.05), radius: 6, x: 0, y: 3)
+                    }
+                }
+
+                VStack(alignment: .leading, spacing: 16) {
+                    Text("Decoding RTF Exchanges")
+                        .font(.title3.bold())
+                    Text("Radio calls follow a predictable rhythm. Learning the intent behind each exchange helps you follow the story in real time and anticipate what comes next.")
+                        .foregroundStyle(.secondary)
+                    ForEach(exchanges) { item in
+                        VStack(alignment: .leading, spacing: 6) {
+                            Text(item.call)
+                                .font(.headline)
+                            Text(item.meaning)
+                                .font(.body)
+                                .foregroundStyle(.secondary)
+                        }
+                        .padding()
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(.background, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+                        .shadow(color: .black.opacity(0.05), radius: 6, x: 0, y: 3)
+                    }
+                }
+
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("Looking for live audio?")
+                        .font(.headline)
+                    Text("Check the curated frequency list and streaming resources for your chosen airport. Add direct audio streaming integrations here.")
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .padding()
+        }
+        .background(Color(.systemGroupedBackground))
+        .navigationTitle("Frequencies")
+    }
+}

--- a/ios/PlaneSpotter/PlaneSpotter/Views/PlaceholderView.swift
+++ b/ios/PlaneSpotter/PlaneSpotter/Views/PlaceholderView.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+struct PlaceholderView: View {
+    let title: String
+    let message: String
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 16) {
+                Image(systemName: "hammer")
+                    .font(.system(size: 48))
+                    .foregroundStyle(.gray)
+                Text(title)
+                    .font(.title2.bold())
+                Text(message)
+                    .font(.body)
+                    .multilineTextAlignment(.center)
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity)
+            .padding()
+        }
+        .background(Color(.systemGroupedBackground))
+        .navigationTitle(title)
+    }
+}

--- a/ios/PlaneSpotter/PlaneSpotter/Views/ResourceTagView.swift
+++ b/ios/PlaneSpotter/PlaneSpotter/Views/ResourceTagView.swift
@@ -1,0 +1,62 @@
+import SwiftUI
+
+struct ResourceTagView: View {
+    let category: String
+
+    private var label: String {
+        switch category {
+        case "map": return "Airfield Map"
+        case "guide": return "Spotting Guide"
+        case "official": return "Official"
+        case "community": return "Community"
+        case "video": return "Video"
+        default: return "Resource"
+        }
+    }
+
+    private var tint: Color {
+        switch category {
+        case "map": return Color.green.opacity(0.2)
+        case "guide": return Color.blue.opacity(0.2)
+        case "official": return Color.gray.opacity(0.2)
+        case "community": return Color.purple.opacity(0.2)
+        case "video": return Color.orange.opacity(0.2)
+        default: return Color.gray.opacity(0.2)
+        }
+    }
+
+    private var textColor: Color {
+        switch category {
+        case "map": return .green
+        case "guide": return .blue
+        case "official": return .gray
+        case "community": return .purple
+        case "video": return .orange
+        default: return .gray
+        }
+    }
+
+    var body: some View {
+        Text(label)
+            .font(.caption.weight(.semibold))
+            .padding(.horizontal, 12)
+            .padding(.vertical, 6)
+            .foregroundStyle(textColor)
+            .background(tint, in: Capsule())
+    }
+}
+
+struct ResourceTagView_Previews: PreviewProvider {
+    static var previews: some View {
+        VStack(spacing: 12) {
+            ResourceTagView(category: "map")
+            ResourceTagView(category: "guide")
+            ResourceTagView(category: "official")
+            ResourceTagView(category: "community")
+            ResourceTagView(category: "video")
+            ResourceTagView(category: "other")
+        }
+        .padding()
+        .previewLayout(.sizeThatFits)
+    }
+}

--- a/ios/README.md
+++ b/ios/README.md
@@ -1,0 +1,62 @@
+# Plane Spotter iOS
+
+This directory contains a native SwiftUI implementation of the Plane Spotter client so you can run the experience on iPhone and iPad. The app talks to the existing Django REST API that powers the web experience.
+
+## Features
+
+- SwiftUI navigation hub that mirrors the sections of the web product.
+- Airport list with search, pull-to-refresh, and detail pages.
+- Airport detail view that renders frequencies, spotting locations, and external resources with native styling and a MapKit preview.
+- Map view that plots all airports and lets you jump between them with animated camera transitions.
+- Frequency learning guide with rich text cards.
+- Placeholder screens for Live ADS-B, Logbook, and Community to highlight the API integration points that still need to be built.
+
+## Getting started
+
+1. Open `ios/PlaneSpotter/PlaneSpotter.xcodeproj` in Xcode 15 or newer (iOS 17 SDK).
+2. Update the `API_BASE_URL` entry in `PlaneSpotter/Info.plist` if your backend is not running on `http://localhost:8000/api`.
+3. (Optional) Configure App Transport Security in the project settings if you are connecting to a non-HTTPS development server.
+4. Build and run the app on the iOS simulator or a physical device.
+
+### Running the backend locally
+
+```bash
+# From the repository root
+python manage.py migrate
+python manage.py runserver 0.0.0.0:8000
+```
+
+Ensure your simulator can reach the backend host. When running inside Docker, replace `localhost` with your machine IP and update `API_BASE_URL` accordingly.
+
+## Extending the app
+
+- **Live ADS-B**: integrate with a live data provider (e.g. ADSBExchange) and present aircraft overlays in a dedicated view.
+- **Logbook sync**: call the `/api/seen/` endpoint using authenticated requests to keep a local spotting log.
+- **Community**: wire up `/api/posts/`, `/api/comments/`, and `/api/badges/` to deliver social features.
+- **Offline caching**: wrap the networking layer with persistence to support offline browsing when at the airport.
+
+## Project structure
+
+```
+ios/PlaneSpotter
+├── PlaneSpotter.xcodeproj
+└── PlaneSpotter
+    ├── Assets.xcassets
+    ├── Components
+    ├── Info.plist
+    ├── Models
+    ├── Networking
+    ├── Utilities
+    ├── ViewModels
+    └── Views
+```
+
+Each view model performs async API calls using `APIClient`, which automatically converts snake_case JSON responses into Swift naming conventions.
+
+## Known limitations
+
+- Authentication flows are not implemented yet.
+- Airport photos, logbook updates, and community posts still require native UI.
+- Map clustering is not yet enabled for dense airport regions.
+
+Contributions and enhancements are welcome!


### PR DESCRIPTION
## Summary
- add a native SwiftUI Plane Spotter application that mirrors the web home navigation
- implement models, networking, and view models to consume the existing Django REST API
- build airport detail/map experiences plus documentation for configuring and running the iOS project

## Testing
- not run (iOS project requires Xcode to build)

------
https://chatgpt.com/codex/tasks/task_e_68dd4e1d975c8324b7e461f0c8eca872