### PR TITLE
Expand community engagement insights and automation

### DIFF
--- a/core/migrations/0002_forum_topics_and_challenges.py
+++ b/core/migrations/0002_forum_topics_and_challenges.py
@@ -1,0 +1,56 @@
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ("core", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="ForumTopic",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("slug", models.SlugField(max_length=64, unique=True)),
+                ("title", models.CharField(max_length=120)),
+                ("description", models.TextField(blank=True)),
+                ("order", models.PositiveIntegerField(default=0)),
+            ],
+            options={"ordering": ("order", "title")},
+        ),
+        migrations.AddField(
+            model_name="post",
+            name="topic",
+            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name="posts", to="core.forumtopic"),
+        ),
+        migrations.CreateModel(
+            name="Challenge",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("code", models.CharField(max_length=60, unique=True)),
+                ("title", models.CharField(max_length=150)),
+                ("description", models.TextField()),
+                ("start", models.DateField()),
+                ("end", models.DateField()),
+                ("target_count", models.PositiveIntegerField(default=1)),
+                ("badge_reward", models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, to="core.badge")),
+            ],
+            options={"ordering": ("-start",)},
+        ),
+        migrations.CreateModel(
+            name="UserChallengeProgress",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("progress", models.PositiveIntegerField(default=0)),
+                ("completed", models.BooleanField(default=False)),
+                ("last_updated", models.DateTimeField(auto_now=True)),
+                ("challenge", models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name="participants", to="core.challenge")),
+                ("user", models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name="challenges", to=settings.AUTH_USER_MODEL)),
+            ],
+            options={"unique_together": {("user", "challenge")}},
+        ),
+    ]

--- a/core/models.py
+++ b/core/models.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.db import models
+from django.utils import timezone
 
 class Airport(models.Model):
     icao = models.CharField(max_length=4, unique=True)
@@ -49,9 +50,25 @@ class UserSeen(models.Model):
     class Meta:
         unique_together = ("user", "aircraft")
 
+class ForumTopic(models.Model):
+    """A high level discussion area for organising community conversations."""
+
+    slug = models.SlugField(max_length=64, unique=True)
+    title = models.CharField(max_length=120)
+    description = models.TextField(blank=True)
+    order = models.PositiveIntegerField(default=0)
+
+    class Meta:
+        ordering = ("order", "title")
+
+    def __str__(self):
+        return self.title
+
+
 class Post(models.Model):
     user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
     airport = models.ForeignKey(Airport, on_delete=models.SET_NULL, null=True, blank=True)
+    topic = models.ForeignKey(ForumTopic, on_delete=models.SET_NULL, null=True, blank=True, related_name="posts")
     title = models.CharField(max_length=200)
     body = models.TextField()
     created = models.DateTimeField(auto_now_add=True)
@@ -74,4 +91,58 @@ class UserBadge(models.Model):
 
     class Meta:
         unique_together = ("user", "badge")
+
+
+class Challenge(models.Model):
+    """Seasonal or ongoing engagement prompts encouraging user participation."""
+
+    code = models.CharField(max_length=60, unique=True)
+    title = models.CharField(max_length=150)
+    description = models.TextField()
+    start = models.DateField()
+    end = models.DateField()
+    target_count = models.PositiveIntegerField(default=1)
+    badge_reward = models.ForeignKey(Badge, on_delete=models.SET_NULL, null=True, blank=True)
+
+    class Meta:
+        ordering = ("-start",)
+
+    def __str__(self):
+        return self.title
+
+    @property
+    def is_active(self):
+        today = timezone.now().date()
+        return self.start <= today <= self.end
+
+    @property
+    def days_remaining(self):
+        today = timezone.now().date()
+        if today > self.end:
+            return 0
+        return max((self.end - today).days, 0)
+
+
+class UserChallengeProgress(models.Model):
+    """Tracks a user's progress toward completing a challenge."""
+
+    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name="challenges")
+    challenge = models.ForeignKey(Challenge, on_delete=models.CASCADE, related_name="participants")
+    progress = models.PositiveIntegerField(default=0)
+    completed = models.BooleanField(default=False)
+    last_updated = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        unique_together = ("user", "challenge")
+
+    def __str__(self):
+        return f"{self.user} – {self.challenge}"
+
+    def save(self, *args, **kwargs):
+        target = self.challenge.target_count or 0
+        if target <= 0:
+            self.completed = True
+        else:
+            self.completed = self.progress >= target
+        super().save(*args, **kwargs)
 

--- a/core/serializers.py
+++ b/core/serializers.py
@@ -1,5 +1,23 @@
 from rest_framework import serializers
-from .models import Airport, Frequency, SpottingLocation, Photo, Aircraft, UserSeen, Post, Comment, Badge, UserBadge
+from django.contrib.auth import get_user_model
+from .models import (
+    Airport,
+    Frequency,
+    SpottingLocation,
+    Photo,
+    Aircraft,
+    UserSeen,
+    Post,
+    Comment,
+    Badge,
+    UserBadge,
+    ForumTopic,
+    Challenge,
+    UserChallengeProgress,
+)
+
+
+User = get_user_model()
 
 class FrequencySerializer(serializers.ModelSerializer):
     class Meta:
@@ -18,6 +36,20 @@ class AirportSerializer(serializers.ModelSerializer):
         model = Airport
         fields = "__all__"
 
+
+class ForumTopicSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ForumTopic
+        fields = "__all__"
+
+
+class ForumTopicSummarySerializer(serializers.ModelSerializer):
+    recent_posts = serializers.IntegerField(read_only=True)
+
+    class Meta:
+        model = ForumTopic
+        fields = ("id", "slug", "title", "description", "order", "recent_posts")
+
 class PhotoSerializer(serializers.ModelSerializer):
     class Meta:
         model = Photo
@@ -34,9 +66,20 @@ class UserSeenSerializer(serializers.ModelSerializer):
         fields = "__all__"
 
 class PostSerializer(serializers.ModelSerializer):
+    user_display = serializers.SerializerMethodField()
+    comment_count = serializers.SerializerMethodField()
+    topic = serializers.PrimaryKeyRelatedField(queryset=ForumTopic.objects.all(), allow_null=True, required=False)
+
     class Meta:
         model = Post
         fields = "__all__"
+
+    def get_user_display(self, obj):
+        username_field = getattr(User, "USERNAME_FIELD", "username")
+        return getattr(obj.user, username_field, str(obj.user))
+
+    def get_comment_count(self, obj):
+        return getattr(obj, "comment_count", obj.comments.count())
 
 class CommentSerializer(serializers.ModelSerializer):
     class Meta:
@@ -49,7 +92,75 @@ class BadgeSerializer(serializers.ModelSerializer):
         fields = "__all__"
 
 class UserBadgeSerializer(serializers.ModelSerializer):
+    user_display = serializers.SerializerMethodField()
+    badge_name = serializers.CharField(source="badge.name", read_only=True)
+
     class Meta:
         model = UserBadge
         fields = "__all__"
+
+    def get_user_display(self, obj):
+        username_field = getattr(User, "USERNAME_FIELD", "username")
+        return getattr(obj.user, username_field, str(obj.user))
+
+
+class ChallengeSerializer(serializers.ModelSerializer):
+    is_active = serializers.SerializerMethodField()
+    days_remaining = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Challenge
+        fields = (
+            "id",
+            "code",
+            "title",
+            "description",
+            "start",
+            "end",
+            "target_count",
+            "badge_reward",
+            "is_active",
+            "days_remaining",
+        )
+
+    def get_is_active(self, obj):
+        return obj.is_active
+
+    def get_days_remaining(self, obj):
+        return obj.days_remaining
+
+
+class UserChallengeProgressSerializer(serializers.ModelSerializer):
+    user_display = serializers.SerializerMethodField()
+    challenge_title = serializers.CharField(source="challenge.title", read_only=True)
+    is_active = serializers.SerializerMethodField()
+    progress_percentage = serializers.SerializerMethodField()
+
+    class Meta:
+        model = UserChallengeProgress
+        fields = (
+            "id",
+            "user",
+            "challenge",
+            "progress",
+            "completed",
+            "last_updated",
+            "user_display",
+            "challenge_title",
+            "is_active",
+            "progress_percentage",
+        )
+
+    def get_user_display(self, obj):
+        username_field = getattr(User, "USERNAME_FIELD", "username")
+        return getattr(obj.user, username_field, str(obj.user))
+
+    def get_is_active(self, obj):
+        return obj.challenge.is_active
+
+    def get_progress_percentage(self, obj):
+        target = obj.challenge.target_count or 0
+        if target == 0:
+            return 100
+        return min(int((obj.progress / target) * 100), 100)
 

--- a/core/tests.py
+++ b/core/tests.py
@@ -1,3 +1,160 @@
-from django.test import TestCase
+from datetime import date, timedelta
 
-# Create your tests here.
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+from .models import (
+    Airport,
+    Badge,
+    Challenge,
+    ForumTopic,
+    Post,
+    UserBadge,
+    UserChallengeProgress,
+)
+from .serializers import ChallengeSerializer, UserChallengeProgressSerializer
+
+
+class CommunityFeedViewTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.user = get_user_model().objects.create_user("spotter", "spotter@example.com", "password123")
+        self.topic = ForumTopic.objects.create(slug="general", title="General Chat")
+        self.airport = Airport.objects.create(
+            icao="EGLL",
+            iata="LHR",
+            name="Heathrow",
+            city="London",
+            country="United Kingdom",
+            lat=51.47,
+            lon=-0.4543,
+        )
+        self.post = Post.objects.create(user=self.user, title="First trip", body="Loved the spotting weekend!", topic=self.topic, airport=self.airport)
+        self.badge = Badge.objects.create(code="FIRST_POST", name="First Post", description="Shared your first post")
+        UserBadge.objects.create(user=self.user, badge=self.badge)
+        self.challenge = Challenge.objects.create(
+            code="FIRST_WEEK",
+            title="First Week Challenge",
+            description="Share a post in your first week",
+            start=date.today() - timedelta(days=1),
+            end=date.today() + timedelta(days=6),
+            target_count=1,
+        )
+        self.progress = UserChallengeProgress.objects.create(
+            user=self.user,
+            challenge=self.challenge,
+            progress=1,
+        )
+
+    def test_feed_returns_posts_and_badges(self):
+        url = reverse("community-feed")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertTrue(any(item["type"] == "post" for item in payload))
+        self.assertTrue(any(item["type"] == "badge_awarded" for item in payload))
+        self.assertTrue(any(item["type"] == "challenge_completed" for item in payload))
+        post_event = next(item for item in payload if item["type"] == "post")
+        self.assertEqual(post_event["payload"]["comment_count"], 0)
+        self.assertEqual(post_event["payload"]["topic"], self.topic.id)
+        challenge_event = next(item for item in payload if item["type"] == "challenge_completed")
+        self.assertEqual(challenge_event["payload"]["challenge"], self.challenge.id)
+        self.assertEqual(challenge_event["payload"]["completed"], True)
+
+
+class ChallengeSerializerTests(TestCase):
+    def setUp(self):
+        self.user = get_user_model().objects.create_user("player", "player@example.com", "strongpass")
+        self.badge = Badge.objects.create(code="WEEKEND_SPOT", name="Weekend Warrior")
+        self.challenge = Challenge.objects.create(
+            code="WEEKEND",
+            title="Weekend Spotting Sprint",
+            description="Log five aircraft over the weekend",
+            start=date.today(),
+            end=date.today() + timedelta(days=2),
+            target_count=5,
+            badge_reward=self.badge,
+        )
+        self.progress = UserChallengeProgress.objects.create(user=self.user, challenge=self.challenge, progress=2)
+
+    def test_user_challenge_progress_serializer_enriches_fields(self):
+        data = UserChallengeProgressSerializer(self.progress).data
+        self.assertEqual(data["challenge_title"], self.challenge.title)
+        self.assertEqual(data["user_display"], self.user.username)
+        self.assertIn("is_active", data)
+        self.assertIn("progress_percentage", data)
+        self.assertTrue(data["is_active"])
+        self.assertEqual(data["progress_percentage"], 40)
+
+    def test_challenge_serializer_marks_active_and_remaining_days(self):
+        serialized = ChallengeSerializer(self.challenge).data
+        self.assertTrue(serialized["is_active"])
+        self.assertGreaterEqual(serialized["days_remaining"], 0)
+
+
+class UserChallengeProgressModelTests(TestCase):
+    def setUp(self):
+        self.user = get_user_model().objects.create_user("loop", "loop@example.com", "strongpass")
+        self.challenge = Challenge.objects.create(
+            code="MONTHLY",
+            title="Monthly Marathon",
+            description="Log ten aircraft in a month",
+            start=date.today() - timedelta(days=1),
+            end=date.today() + timedelta(days=28),
+            target_count=3,
+        )
+
+    def test_completed_flag_updates_when_progress_meets_target(self):
+        progress = UserChallengeProgress.objects.create(user=self.user, challenge=self.challenge, progress=3)
+        self.assertTrue(progress.completed)
+
+    def test_completed_flag_can_revert_when_progress_drops(self):
+        progress = UserChallengeProgress.objects.create(user=self.user, challenge=self.challenge, progress=3)
+        progress.refresh_from_db()
+        progress.progress = 1
+        progress.save()
+        progress.refresh_from_db()
+        self.assertFalse(progress.completed)
+
+
+class EngagementSummaryViewTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.user = get_user_model().objects.create_user("writer", "writer@example.com", "password123")
+        self.topic = ForumTopic.objects.create(slug="news", title="News")
+        self.airport = Airport.objects.create(
+            icao="EGCC",
+            iata="MAN",
+            name="Manchester",
+            city="Manchester",
+            country="United Kingdom",
+            lat=53.365,
+            lon=-2.2727,
+        )
+        for _ in range(3):
+            Post.objects.create(user=self.user, title="Update", body="Big movements", topic=self.topic, airport=self.airport)
+        badge = Badge.objects.create(code="ACTIVE", name="Staying Active")
+        UserBadge.objects.create(user=self.user, badge=badge)
+        self.challenge = Challenge.objects.create(
+            code="DAILY",
+            title="Daily Diary",
+            description="Share daily updates",
+            start=date.today() - timedelta(days=2),
+            end=date.today() + timedelta(days=5),
+            target_count=1,
+        )
+
+    def test_engagement_summary_highlights_trends(self):
+        url = reverse("community-engagement")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertIn("trending_topics", payload)
+        self.assertTrue(payload["trending_topics"])
+        self.assertEqual(payload["trending_topics"][0]["slug"], "news")
+        self.assertTrue(payload["active_challenges"])
+        challenge_payload = payload["active_challenges"][0]
+        self.assertIn("is_active", challenge_payload)
+        self.assertTrue(payload["recent_badges"])

--- a/core/urls.py
+++ b/core/urls.py
@@ -1,8 +1,22 @@
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter
-from .views import (AirportViewSet, FrequencyViewSet, SpottingLocationViewSet, PhotoViewSet,
-                    AircraftViewSet, UserSeenViewSet, PostViewSet, CommentViewSet,
-                    BadgeViewSet, UserBadgeViewSet)
+from .views import (
+    AirportViewSet,
+    FrequencyViewSet,
+    SpottingLocationViewSet,
+    PhotoViewSet,
+    AircraftViewSet,
+    UserSeenViewSet,
+    PostViewSet,
+    CommentViewSet,
+    BadgeViewSet,
+    UserBadgeViewSet,
+    ForumTopicViewSet,
+    ChallengeViewSet,
+    UserChallengeProgressViewSet,
+    CommunityFeedView,
+    EngagementSummaryView,
+)
 
 router = DefaultRouter()
 router.register(r"airports", AirportViewSet)
@@ -15,8 +29,13 @@ router.register(r"posts", PostViewSet)
 router.register(r"comments", CommentViewSet)
 router.register(r"badges", BadgeViewSet)
 router.register(r"userbadges", UserBadgeViewSet)
+router.register(r"topics", ForumTopicViewSet)
+router.register(r"challenges", ChallengeViewSet)
+router.register(r"challenge-progress", UserChallengeProgressViewSet)
 
 urlpatterns = [
     path("", include(router.urls)),
+    path("community/feed/", CommunityFeedView.as_view(), name="community-feed"),
+    path("community/engagement/", EngagementSummaryView.as_view(), name="community-engagement"),
 ]
 

--- a/core/views.py
+++ b/core/views.py
@@ -1,8 +1,39 @@
-from rest_framework import viewsets, permissions
-from .models import Airport, Frequency, SpottingLocation, Photo, Aircraft, UserSeen, Post, Comment, Badge, UserBadge
-from .serializers import (AirportSerializer, FrequencySerializer, SpottingLocationSerializer, PhotoSerializer,
-                          AircraftSerializer, UserSeenSerializer, PostSerializer, CommentSerializer,
-                          BadgeSerializer, UserBadgeSerializer)
+from datetime import timedelta
+
+from django.db.models import Count, Q
+from django.utils import timezone
+from rest_framework import viewsets, permissions, response, views
+from .models import (
+    Airport,
+    Frequency,
+    SpottingLocation,
+    Photo,
+    Aircraft,
+    UserSeen,
+    Post,
+    Comment,
+    Badge,
+    UserBadge,
+    ForumTopic,
+    Challenge,
+    UserChallengeProgress,
+)
+from .serializers import (
+    AirportSerializer,
+    FrequencySerializer,
+    SpottingLocationSerializer,
+    PhotoSerializer,
+    AircraftSerializer,
+    UserSeenSerializer,
+    PostSerializer,
+    CommentSerializer,
+    BadgeSerializer,
+    UserBadgeSerializer,
+    ForumTopicSerializer,
+    ForumTopicSummarySerializer,
+    ChallengeSerializer,
+    UserChallengeProgressSerializer,
+)
 
 class AirportViewSet(viewsets.ModelViewSet):
     """Expose airports with their related frequencies and spotting locations."""
@@ -40,8 +71,18 @@ class UserSeenViewSet(viewsets.ModelViewSet):
     serializer_class = UserSeenSerializer
     permission_classes = [permissions.IsAuthenticated]
 
+class ForumTopicViewSet(viewsets.ModelViewSet):
+    queryset = ForumTopic.objects.all()
+    serializer_class = ForumTopicSerializer
+    permission_classes = [permissions.IsAuthenticatedOrReadOnly]
+
+
 class PostViewSet(viewsets.ModelViewSet):
-    queryset = Post.objects.all().order_by("-created")
+    queryset = (
+        Post.objects.select_related("user", "airport", "topic")
+        .annotate(comment_count=Count("comments"))
+        .order_by("-created")
+    )
     serializer_class = PostSerializer
     permission_classes = [permissions.IsAuthenticatedOrReadOnly]
 
@@ -59,4 +100,97 @@ class UserBadgeViewSet(viewsets.ModelViewSet):
     queryset = UserBadge.objects.all()
     serializer_class = UserBadgeSerializer
     permission_classes = [permissions.IsAuthenticated]
+
+
+class ChallengeViewSet(viewsets.ModelViewSet):
+    queryset = Challenge.objects.all()
+    serializer_class = ChallengeSerializer
+    permission_classes = [permissions.IsAuthenticatedOrReadOnly]
+
+
+class UserChallengeProgressViewSet(viewsets.ModelViewSet):
+    queryset = UserChallengeProgress.objects.select_related("challenge", "user").all()
+    serializer_class = UserChallengeProgressSerializer
+    permission_classes = [permissions.IsAuthenticated]
+
+
+class CommunityFeedView(views.APIView):
+    permission_classes = [permissions.AllowAny]
+
+    def get(self, request):
+        posts = (
+            Post.objects.select_related("user", "airport", "topic")
+            .annotate(comment_count=Count("comments"))
+            .order_by("-created")[:10]
+        )
+        badges = UserBadge.objects.select_related("user", "badge").order_by("-awarded_at")[:10]
+        completions = (
+            UserChallengeProgress.objects.select_related("challenge", "user")
+            .filter(completed=True)
+            .order_by("-last_updated")[:10]
+        )
+
+        events = []
+
+        for post in posts:
+            events.append(
+                {
+                    "type": "post",
+                    "timestamp": post.created,
+                    "payload": PostSerializer(post, context={"request": request}).data,
+                }
+            )
+
+        for badge in badges:
+            events.append(
+                {
+                    "type": "badge_awarded",
+                    "timestamp": badge.awarded_at,
+                    "payload": UserBadgeSerializer(badge, context={"request": request}).data,
+                }
+            )
+
+        for progress in completions:
+            events.append(
+                {
+                    "type": "challenge_completed",
+                    "timestamp": progress.last_updated,
+                    "payload": UserChallengeProgressSerializer(progress, context={"request": request}).data,
+                }
+            )
+
+        events.sort(key=lambda item: item["timestamp"], reverse=True)
+
+        for event in events:
+            event["timestamp"] = event["timestamp"].isoformat()
+
+        return response.Response(events[:20])
+
+
+class EngagementSummaryView(views.APIView):
+    permission_classes = [permissions.AllowAny]
+
+    def get(self, request):
+        now = timezone.now()
+        recent_window = now - timedelta(days=30)
+
+        trending_topics = (
+            ForumTopic.objects.annotate(
+                recent_posts=Count("posts", filter=Q(posts__created__gte=recent_window))
+            )
+            .order_by("-recent_posts", "order", "title")[:5]
+        )
+
+        today = now.date()
+        active_challenges = Challenge.objects.filter(end__gte=today).order_by("start")
+
+        recent_badges = UserBadge.objects.select_related("user", "badge").order_by("-awarded_at")[:5]
+
+        data = {
+            "trending_topics": ForumTopicSummarySerializer(trending_topics, many=True, context={"request": request}).data,
+            "active_challenges": ChallengeSerializer(active_challenges, many=True, context={"request": request}).data,
+            "recent_badges": UserBadgeSerializer(recent_badges, many=True, context={"request": request}).data,
+        }
+
+        return response.Response(data)
 

--- a/docs/community_engagement_review.md
+++ b/docs/community_engagement_review.md
@@ -1,0 +1,24 @@
+# Community Engagement Review
+
+## Current Strengths
+- Rich aviation data model covering airports, spotting locations, and community posts provides a solid base for storytelling.
+- Existing badge system gives you a foundation for gamified nudges.
+- REST API already exposes most domain entities, simplifying client integrations.
+
+## Opportunities for Improvement
+1. **Surface Momentum Quickly**
+   - Provide a lightweight engagement summary endpoint that front-ends can call to show trending topics, active challenges, and recent badge earners on dashboards.
+   - Highlight activity in the first screen after login to encourage return visits.
+2. **Guided Challenges**
+   - Track completion state automatically when users update challenge progress so admins do not have to audit it manually.
+   - Include progress percentages in the API response so clients can show friendly progress bars.
+3. **Contextual Feed Items**
+   - Mix challenge completions alongside posts and badge unlocks so users see more ways to participate.
+   - Offer quick actions (e.g., join challenge, reply to trending topic) directly from the feed cards.
+
+## Next Steps
+- Add server-side guardrails to keep challenge status accurate even if clients do not set the `completed` flag explicitly.
+- Build UI widgets that consume the new engagement summary API and experiment with different layouts (hero banner vs. sidebar module).
+- Continue investing in analytics (e.g., streak tracking, heatmaps of airport activity) to personalize nudges for each spotter.
+
+These adjustments should help the community discover new conversations faster, celebrate progress automatically, and maintain reliable challenge data as participation scales.


### PR DESCRIPTION
## Summary
- add automatic completion handling and activity metadata to challenges for richer progress tracking
- extend community APIs with challenge completion events and a new engagement summary endpoint
- document community engagement recommendations and cover the new behavior with unit tests

## Testing
- `python -m pip install django==5.0.6 djangorestframework==3.15.1` *(fails: proxy blocks package downloads)*
- `python manage.py test` *(fails: Django not installed in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd4b4344ec8324b5bf38f83d4344f1