### PR TITLE
Add premium strategy recommendations

### DIFF
--- a/docs/standout-strategy.md
+++ b/docs/standout-strategy.md
@@ -1,0 +1,29 @@
+# Plane Spotter Product Strategy Enhancements
+
+## 1. Differentiate the Core Data Experience
+- **Layer data intelligence on existing modules.** Airports, frequencies, live ADS-B, and spotting log features already exist across the app – enrich them with analytics such as busiest hours, typical runway configs, and aircraft mix trends using historical logs.【F:web/src/app/page.tsx†L5-L31】【F:web/src/app/live/page.tsx†L1-L164】【F:web/src/app/logbook/spotting-log.tsx†L1-L196】
+- **Curate "spotter playbooks" per airport.** Expand each airport detail page with arrival/departure cheatsheets, photography guidance, and seasonal highlights to make subscriptions feel essential.【F:web/src/app/airports/page.tsx†L1-L34】
+- **Automate proximity insights.** Combine user location with airport and frequency databases to recommend the best facility to visit right now, plus estimated travel time and current traffic levels.【F:web/src/app/page.tsx†L5-L31】
+
+## 2. Build Community-First Engagement Loops
+- **Turn the Community section into a daily habit.** Layer on streaks for daily check-ins, prompt members to share spotting tips, and surface trending photos. Tie these to existing badge concepts in the backend to reinforce status.【F:web/src/app/page.tsx†L9-L13】【F:docs/review-and-roadmap.md†L6-L23】
+- **Launch collaborative missions.** Weekly challenges (e.g., "catch three retro liveries") with shared progress bars encourage social interaction and can unlock limited-time badges or partner rewards.
+- **Host live virtual events.** Pair the ADS-B map with live commentary or ATC decoding sessions where experts walk through interesting traffic scenarios, then archive replays for premium subscribers.【F:web/src/app/live/page.tsx†L1-L164】【F:web/src/app/frequencies/page.tsx†L1-L96】
+
+## 3. Monetize Through Tiered Value
+- **Free tier:** access to basic airport info, limited live map refreshes, and personal logbook tracking.
+- **Spotter Pro (subscription):** unlimited live ADS-B updates, advanced filters (airline, equipment, altitude bands), downloadable trip plans, and offline airport packs for travel days.【F:web/src/app/live/page.tsx†L1-L164】【F:web/src/app/logbook/spotting-log.tsx†L1-L196】
+- **Spotter Elite (annual or lifetime):** backstage event access, partner discounts (museums, aviation stores), priority support, and data API credits for creators who need integration rights.
+- **Add-on revenue:** curated merchandise drops tied to challenges, photography workshops, and co-branded airport tours.
+
+## 4. Personalization & Retention
+- **Smart notifications.** Alert users when rare aircraft enter their radius, when friends log new sightings, or when weather aligns for great photography conditions. Use in-app nudges before expanding to push notifications.
+- **Dynamic onboarding.** Ask new members about preferred airlines, aircraft types, and home airport to tailor the home screen modules immediately.【F:web/src/app/logbook/spotting-log.tsx†L31-L84】
+- **Milestone storytelling.** Generate shareable summaries after milestone counts (50th aircraft, 10th airport) with custom graphics to fuel organic marketing.
+
+## 5. Operational Foundations for Trust
+- **Data provenance & accuracy.** Highlight data sources, update cadences, and verification processes so enthusiasts trust premium insights.
+- **Moderation tooling.** Implement community guidelines, AI-assisted flagging, and volunteer moderators to keep discussions constructive before scale becomes an issue.
+- **Performance & availability.** Continue optimizing the Django + Next.js stack with caching, server-sent events or WebSockets for live traffic, and uptime transparency dashboards.【F:docs/review-and-roadmap.md†L6-L71】
+
+Investing in these pillars turns Plane Spotter from a useful directory into the daily command center for aviation enthusiasts—making premium tiers far more compelling and defensible.


### PR DESCRIPTION
## Summary
- add a product strategy guide highlighting opportunities to differentiate the data experience, grow community engagement, and monetize tiers
- outline personalization, retention, and operational investments to increase perceived value for paying users

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd5395ad28832485d78173361cab7c