### PR TITLE
Add live aircraft fleet feed endpoint

### DIFF
--- a/backend/settings.py
+++ b/backend/settings.py
@@ -138,3 +138,13 @@ REST_FRAMEWORK = {
         "rest_framework_simplejwt.authentication.JWTAuthentication",
     )
 }
+
+
+# Aircraft feed configuration (see core.services.aircraft_feed)
+AIRCRAFT_FEED_URL = os.getenv(
+    "AIRCRAFT_FEED_URL",
+    "https://opensky-network.org/datasets/metadata/aircraftDatabase.csv",
+)
+AIRCRAFT_FEED_TIMEOUT = int(os.getenv("AIRCRAFT_FEED_TIMEOUT", "15"))
+AIRCRAFT_FEED_CACHE_SECONDS = int(os.getenv("AIRCRAFT_FEED_CACHE_SECONDS", "900"))
+AIRCRAFT_FEED_MAX_RESULTS = int(os.getenv("AIRCRAFT_FEED_MAX_RESULTS", "200"))

--- a/core/services/__init__.py
+++ b/core/services/__init__.py
@@ -1,0 +1,5 @@
+"""Reusable service helpers for the core app."""
+
+from .aircraft_feed import fetch_live_fleet, AircraftFeedError
+
+__all__ = ["fetch_live_fleet", "AircraftFeedError"]

--- a/core/services/aircraft_feed.py
+++ b/core/services/aircraft_feed.py
@@ -1,0 +1,140 @@
+"""Utilities for fetching aircraft fleet data from external feeds."""
+
+from __future__ import annotations
+
+import csv
+import io
+import urllib.request
+from dataclasses import dataclass
+from typing import Dict, Iterable, Iterator, List, Optional
+
+from django.conf import settings
+from django.core.cache import cache
+
+
+class AircraftFeedError(RuntimeError):
+    """Raised when a live aircraft feed cannot be retrieved."""
+
+
+@dataclass(frozen=True)
+class AircraftRecord:
+    icao24: str
+    registration: str
+    manufacturer: str
+    model: str
+    type_code: str
+    icao_aircraft_type: str
+    operator: str
+    operator_callsign: str
+    owner: str
+    serial_number: str
+    built: str
+    country: str
+
+    @classmethod
+    def from_row(cls, row: Dict[str, str]) -> "AircraftRecord":
+        """Normalise a CSV row from the OpenSky aircraft database."""
+
+        def clean(key: str) -> str:
+            return (row.get(key) or "").strip()
+
+        return cls(
+            icao24=clean("icao24").lower(),
+            registration=clean("registration"),
+            manufacturer=clean("manufacturername") or clean("manufacturericao"),
+            model=clean("model"),
+            type_code=clean("typecode"),
+            icao_aircraft_type=clean("icaoaircrafttype"),
+            operator=clean("operator"),
+            operator_callsign=clean("operatorcallsign"),
+            owner=clean("owner"),
+            serial_number=clean("serialnumber"),
+            built=clean("built"),
+            country=clean("registeredcountry") or clean("operatorcountry") or clean("owner")
+        )
+
+    def as_dict(self) -> Dict[str, str]:
+        return {
+            "icao24": self.icao24,
+            "registration": self.registration,
+            "manufacturer": self.manufacturer,
+            "model": self.model,
+            "type_code": self.type_code,
+            "icao_aircraft_type": self.icao_aircraft_type,
+            "operator": self.operator,
+            "operator_callsign": self.operator_callsign,
+            "owner": self.owner,
+            "serial_number": self.serial_number,
+            "built": self.built,
+            "country": self.country,
+        }
+
+
+def _open_feed(url: str) -> io.TextIOBase:
+    """Open the remote CSV feed with sane defaults."""
+
+    try:
+        request = urllib.request.Request(
+            url,
+            headers={
+                "User-Agent": "PlaneSpotter/1.0 (+https://github.com/)",
+                "Accept": "text/csv,application/octet-stream",
+            },
+        )
+        response = urllib.request.urlopen(request, timeout=settings.AIRCRAFT_FEED_TIMEOUT)
+        return io.TextIOWrapper(response, encoding="utf-8", errors="replace")
+    except Exception as exc:  # pragma: no cover - network errors mocked in tests
+        raise AircraftFeedError(str(exc)) from exc
+
+
+def _iter_records(reader: Iterable[Dict[str, str]]) -> Iterator[AircraftRecord]:
+    for row in reader:
+        record = AircraftRecord.from_row(row)
+        if record.registration or record.icao24:
+            yield record
+
+
+def fetch_live_fleet(
+    *,
+    registration: Optional[str] = None,
+    country: Optional[str] = None,
+    limit: Optional[int] = None,
+    url: Optional[str] = None,
+    use_cache: bool = True,
+) -> List[Dict[str, str]]:
+    """Fetch live aircraft data and return a list of dictionaries.
+
+    Results can be filtered by registration substring and country (case insensitive).
+    """
+
+    limit = limit or settings.AIRCRAFT_FEED_MAX_RESULTS
+    limit = min(limit, settings.AIRCRAFT_FEED_MAX_RESULTS)
+    cache_key = None
+
+    registration_filter = registration.lower() if registration else None
+    country_filter = country.lower() if country else None
+
+    if use_cache and registration_filter is None and country_filter is None:
+        cache_key = f"aircraft-feed:{limit}:{url or ''}"
+        cached = cache.get(cache_key)
+        if cached is not None:
+            return cached[:limit]
+
+    feed_url = url or settings.AIRCRAFT_FEED_URL
+    with _open_feed(feed_url) as handle:
+        reader = csv.DictReader(handle)
+        matches: List[Dict[str, str]] = []
+        for record in _iter_records(reader):
+            if registration_filter and registration_filter not in record.registration.lower():
+                continue
+            if country_filter and country_filter not in record.country.lower():
+                continue
+            matches.append(record.as_dict())
+            if len(matches) >= limit:
+                break
+
+    if cache_key and not (registration_filter or country_filter):
+        cache.set(cache_key, matches, settings.AIRCRAFT_FEED_CACHE_SECONDS)
+
+    return matches
+

--- a/core/tests.py
+++ b/core/tests.py
@@ -1,3 +1,100 @@
-from django.test import TestCase
+import io
+from unittest import mock
 
-# Create your tests here.
+from django.core.cache import cache
+from django.test import SimpleTestCase, override_settings
+from rest_framework.test import APIRequestFactory
+
+from .services import aircraft_feed
+
+
+SAMPLE_CSV = """icao24,registration,manufacturername,model,typecode,icaoaircrafttype,operator,operatorcallsign,owner,serialnumber,built,registeredcountry,operatorcountry
+abcd12,G-EZTH,Airbus,A320-214,A320,L2J,EASYJET AIRLINE COMPANY LIMITED,EZY,EASYJET AIRLINE,1234,2014,United Kingdom,United Kingdom
+bbcd34,N12345,Boeing,737-8H4,B738,L2J,Southwest Airlines Co.,SWA,Southwest Airlines,9876,2017,United States,United States
+ccdd56,C-FGHI,Bombardier,CRJ900,CRJ9,L2J,Air Canada Express,ACAX,Jazz Aviation,5555,2015,Canada,Canada
+"""
+
+
+class FetchLiveFleetTests(SimpleTestCase):
+    def setUp(self):
+        cache.clear()
+
+    def _mock_feed(self):
+        return io.StringIO(SAMPLE_CSV)
+
+    def test_fetch_live_fleet_filters_registration_and_country(self):
+        with mock.patch.object(aircraft_feed, "_open_feed", side_effect=self._mock_feed):
+            results = aircraft_feed.fetch_live_fleet(
+                registration="G-",
+                country="kingdom",
+                limit=5,
+                use_cache=False,
+            )
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["registration"], "G-EZTH")
+        self.assertEqual(results[0]["country"], "United Kingdom")
+
+    def test_fetch_live_fleet_uses_cache(self):
+        with mock.patch.object(aircraft_feed, "_open_feed", side_effect=self._mock_feed) as opener:
+            first = aircraft_feed.fetch_live_fleet(limit=2)
+            second = aircraft_feed.fetch_live_fleet(limit=2)
+
+        self.assertEqual(len(first), 2)
+        self.assertEqual(first, second)
+        self.assertEqual(opener.call_count, 1)
+
+    def test_fetch_live_fleet_limits_results(self):
+        with mock.patch.object(aircraft_feed, "_open_feed", side_effect=self._mock_feed):
+            results = aircraft_feed.fetch_live_fleet(limit=1, use_cache=False)
+
+        self.assertEqual(len(results), 1)
+
+
+class LiveFleetViewTests(SimpleTestCase):
+    def setUp(self):
+        self.factory = APIRequestFactory()
+
+    @override_settings(AIRCRAFT_FEED_MAX_RESULTS=10)
+    def test_live_fleet_view_returns_payload(self):
+        request = self.factory.get("/api/fleet/live/?limit=2")
+        sample_payload = [
+            {
+                "icao24": "abcd12",
+                "registration": "G-EZTH",
+                "manufacturer": "Airbus",
+                "model": "A320-214",
+                "type_code": "A320",
+                "icao_aircraft_type": "L2J",
+                "operator": "EASYJET AIRLINE COMPANY LIMITED",
+                "operator_callsign": "EZY",
+                "owner": "EASYJET AIRLINE",
+                "serial_number": "1234",
+                "built": "2014",
+                "country": "United Kingdom",
+            }
+        ]
+
+        with mock.patch.object(aircraft_feed, "fetch_live_fleet", return_value=sample_payload):
+            from .views import LiveFleetView
+
+            response = LiveFleetView.as_view()(request)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(response.data["results"], sample_payload)
+
+    def test_live_fleet_view_handles_errors(self):
+        request = self.factory.get("/api/fleet/live/")
+
+        with mock.patch.object(
+            aircraft_feed,
+            "fetch_live_fleet",
+            side_effect=aircraft_feed.AircraftFeedError("network down"),
+        ):
+            from .views import LiveFleetView
+
+            response = LiveFleetView.as_view()(request)
+
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.data["detail"], "network down")

--- a/core/urls.py
+++ b/core/urls.py
@@ -2,7 +2,7 @@ from django.urls import path, include
 from rest_framework.routers import DefaultRouter
 from .views import (AirportViewSet, FrequencyViewSet, SpottingLocationViewSet, PhotoViewSet,
                     AircraftViewSet, UserSeenViewSet, PostViewSet, CommentViewSet,
-                    BadgeViewSet, UserBadgeViewSet)
+                    BadgeViewSet, UserBadgeViewSet, LiveFleetView)
 
 router = DefaultRouter()
 router.register(r"airports", AirportViewSet)
@@ -18,5 +18,6 @@ router.register(r"userbadges", UserBadgeViewSet)
 
 urlpatterns = [
     path("", include(router.urls)),
+    path("fleet/live/", LiveFleetView.as_view(), name="live-fleet"),
 ]
 


### PR DESCRIPTION
## Summary
- add configurable settings for the live aircraft fleet feed and expose helpers under `core.services`
- implement a reusable aircraft feed service with caching, filtering, and error handling
- surface the feed through a new `/api/fleet/live/` endpoint and cover the service/view with unit tests

## Testing
- python manage.py test *(fails: Django is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd7c638e188324b282eee9a1565fda