### PR TITLE
Add community forums section with airport and category pages

### DIFF
--- a/web/src/app/forums/(category)/[category]/page.tsx
+++ b/web/src/app/forums/(category)/[category]/page.tsx
@@ -1,0 +1,85 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { ForumTopicList } from "../../components/topic-list";
+import { GENERAL_FORUMS } from "../../topics";
+
+export default function ForumCategoryPage({
+  params,
+}: {
+  params: { category: string };
+}) {
+  const slug = params.category;
+  const content = GENERAL_FORUMS[slug];
+
+  if (!content) {
+    notFound();
+  }
+
+  return (
+    <main className="min-h-screen bg-slate-50 px-4 py-12">
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-8">
+        <nav className="text-sm text-slate-500">
+          <Link href="/forums" className="font-medium text-blue-600 hover:underline">
+            ← Back to forums
+          </Link>
+        </nav>
+
+        <header className="space-y-4">
+          <div className="space-y-2">
+            <span className="inline-flex items-center rounded-full bg-blue-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-blue-700">
+              {content.title}
+            </span>
+            <h1 className="text-3xl font-bold text-slate-900">{content.title}</h1>
+            <p className="max-w-3xl text-base text-slate-600">{content.intro}</p>
+          </div>
+        </header>
+
+        <div className="grid gap-8 lg:grid-cols-[2fr_1fr]">
+          <section className="space-y-6">
+            <ForumTopicList topics={content.topics} />
+          </section>
+
+          <aside className="space-y-6">
+            <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+              <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500">How to get involved</h2>
+              <p className="mt-2 text-sm text-slate-600">{content.prompt}</p>
+              <ul className="mt-4 space-y-3 text-sm text-slate-600">
+                {content.guidelines.map((tip) => (
+                  <li key={tip} className="flex gap-2">
+                    <span className="mt-1 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-blue-500" />
+                    <span>{tip}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            {content.resources && content.resources.length > 0 && (
+              <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+                <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500">Quick links</h2>
+                <ul className="mt-4 space-y-4">
+                  {content.resources.map((resource) => (
+                    <li key={resource.title}>
+                      <Link
+                        href={resource.href}
+                        className="group block rounded-lg border border-transparent p-3 transition hover:border-blue-200 hover:bg-blue-50"
+                      >
+                        <p className="text-sm font-semibold text-blue-600 group-hover:text-blue-700">{resource.title}</p>
+                        <p className="text-xs text-slate-600">{resource.description}</p>
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            {content.highlight && (
+              <div className="rounded-2xl border border-blue-200 bg-blue-50 p-6 text-sm text-blue-800">
+                {content.highlight}
+              </div>
+            )}
+          </aside>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/web/src/app/forums/airports/[icao]/page.tsx
+++ b/web/src/app/forums/airports/[icao]/page.tsx
@@ -1,0 +1,241 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { apiGet } from "@/lib/api";
+import { ForumTopicList } from "../../components/topic-list";
+import { ForumTopic } from "../../topics";
+
+type Frequency = {
+  id: number;
+  service: string;
+  mhz: string | number;
+  description: string;
+};
+
+type SpottingLocation = {
+  id: number;
+  title: string;
+  description: string;
+  tips: string;
+  lat: number;
+  lon: number;
+};
+
+type AirportResource = {
+  id: number;
+  title: string;
+  url: string;
+  category: string;
+  description: string;
+};
+
+type Airport = {
+  id: number;
+  icao: string;
+  iata: string;
+  name: string;
+  city: string;
+  country: string;
+  lat: number;
+  lon: number;
+  frequencies: Frequency[];
+  spots: SpottingLocation[];
+  resources: AirportResource[];
+};
+
+type PageProps = {
+  params: Promise<{ icao: string }>;
+};
+
+function buildAirportTopics(airport: Airport): ForumTopic[] {
+  const year = new Date().getFullYear();
+  return [
+    {
+      title: `${airport.icao} movements & logbook ${year}`,
+      excerpt: `Daily updates for arrivals, departures, and special visitors at ${airport.name}. Share your logs and attach photos when you can!`,
+      replies: 268,
+      lastActivity: "just now",
+      tags: ["movements", "photos"],
+      pinned: true,
+    },
+    {
+      title: `${airport.city} trip planning help`,
+      excerpt: `Travelling to ${airport.name}? Ask for hotel tips, transport advice, and the best times of day for runway operations.`,
+      replies: 74,
+      lastActivity: "1 hour ago",
+      tags: ["planning", "travel"],
+    },
+    {
+      title: `${airport.icao} ATC & procedure updates`,
+      excerpt: `Log frequency changes, runway works, or new approach procedures impacting spotting around ${airport.icao}.`,
+      replies: 39,
+      lastActivity: "today",
+      tags: ["atc", "ops"],
+    },
+  ];
+}
+
+function buildGuidelines(airport: Airport): string[] {
+  return [
+    `Include runway direction, time, and aircraft type when reporting movements at ${airport.icao}.`,
+    "Avoid sharing anything heard on closed frequencies or from restricted areas.",
+    "Tag your thread titles with [Report], [Question], or [Meetup] so others can skim easily.",
+  ];
+}
+
+function formatMhz(value: string | number): string {
+  const numeric = typeof value === "number" ? value : Number.parseFloat(value);
+  if (Number.isNaN(numeric)) {
+    return String(value);
+  }
+  return numeric.toFixed(3);
+}
+
+export default async function AirportForumPage({ params }: PageProps) {
+  const { icao } = await params;
+  const slug = icao.toUpperCase();
+
+  let airport: Airport | null = null;
+
+  try {
+    airport = await apiGet<Airport>(`/airports/${slug}/`);
+  } catch (error) {
+    console.error(`Failed to load airport forum data for ${slug}`, error);
+    airport = null;
+  }
+
+  if (!airport) {
+    notFound();
+  }
+
+  const topics = buildAirportTopics(airport);
+  const guidelines = buildGuidelines(airport);
+  const quickResources = airport.resources.slice(0, 3);
+  const keyFrequencies = airport.frequencies.slice(0, 4);
+  const featuredSpots = airport.spots.slice(0, 2);
+
+  return (
+    <main className="min-h-screen bg-slate-50 px-4 py-12">
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-8">
+        <nav className="text-sm text-slate-500">
+          <Link href="/forums" className="font-medium text-blue-600 hover:underline">
+            ← Back to forums
+          </Link>
+        </nav>
+
+        <header className="space-y-4">
+          <div className="space-y-2">
+            <span className="inline-flex items-center rounded-full bg-slate-900 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-100">
+              Airport forum
+            </span>
+            <h1 className="text-3xl font-bold text-slate-900">
+              {airport.icao} · {airport.name}
+            </h1>
+            <p className="max-w-3xl text-base text-slate-600">
+              Coordinate spotting at {airport.name} in {airport.city}, {airport.country}. Share daily movement logs, plan
+              meetups, and keep everyone up to speed on operational changes.
+            </p>
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-3">
+            <div className="rounded-2xl border border-slate-200 bg-white p-4">
+              <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Location</p>
+              <p className="mt-2 text-sm font-medium text-slate-900">{airport.city}, {airport.country}</p>
+              <p className="text-xs text-slate-500">{airport.lat.toFixed(4)}, {airport.lon.toFixed(4)}</p>
+            </div>
+            <div className="rounded-2xl border border-slate-200 bg-white p-4">
+              <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Frequencies listed</p>
+              <p className="mt-2 text-2xl font-semibold text-slate-900">{airport.frequencies.length}</p>
+              <p className="text-xs text-slate-500">Check the sidebar for the busiest ones</p>
+            </div>
+            <div className="rounded-2xl border border-slate-200 bg-white p-4">
+              <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Spotting locations</p>
+              <p className="mt-2 text-2xl font-semibold text-slate-900">{airport.spots.length}</p>
+              <p className="text-xs text-slate-500">Top picks are highlighted below</p>
+            </div>
+          </div>
+        </header>
+
+        <div className="grid gap-8 lg:grid-cols-[2fr_1fr]">
+          <section className="space-y-6">
+            <ForumTopicList topics={topics} />
+          </section>
+
+          <aside className="space-y-6">
+            <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+              <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500">Forum guidelines</h2>
+              <ul className="mt-4 space-y-3 text-sm text-slate-600">
+                {guidelines.map((tip) => (
+                  <li key={tip} className="flex gap-2">
+                    <span className="mt-1 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-blue-500" />
+                    <span>{tip}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            {keyFrequencies.length > 0 && (
+              <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+                <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500">Key frequencies</h2>
+                <ul className="mt-4 space-y-3 text-sm text-slate-600">
+                  {keyFrequencies.map((freq) => (
+                    <li key={freq.id} className="flex flex-col">
+                      <span className="font-medium text-slate-900">{freq.service}</span>
+                      <span className="font-mono text-sm text-blue-600">{formatMhz(freq.mhz)} MHz</span>
+                      {freq.description ? (
+                        <span className="text-xs text-slate-500">{freq.description}</span>
+                      ) : null}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            {quickResources.length > 0 && (
+              <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+                <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500">Quick resources</h2>
+                <ul className="mt-4 space-y-4">
+                  {quickResources.map((resource) => (
+                    <li key={resource.id}>
+                      <a
+                        href={resource.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="group block rounded-lg border border-transparent p-3 transition hover:border-blue-200 hover:bg-blue-50"
+                      >
+                        <p className="text-sm font-semibold text-blue-600 group-hover:text-blue-700">{resource.title}</p>
+                        <p className="text-xs text-slate-600">{resource.description}</p>
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+                <Link
+                  href={`/airports/${airport.id}`}
+                  className="mt-4 inline-flex items-center text-sm font-semibold text-blue-600 hover:text-blue-700"
+                >
+                  View full airport guide →
+                </Link>
+              </div>
+            )}
+
+            {featuredSpots.length > 0 && (
+              <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+                <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500">Spotlight locations</h2>
+                <ul className="mt-4 space-y-4 text-sm text-slate-600">
+                  {featuredSpots.map((spot) => (
+                    <li key={spot.id} className="space-y-1">
+                      <p className="font-medium text-slate-900">{spot.title}</p>
+                      {spot.description ? <p>{spot.description}</p> : null}
+                      {spot.tips ? (
+                        <p className="text-xs text-blue-600">Tips: {spot.tips}</p>
+                      ) : null}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </aside>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/web/src/app/forums/components/topic-list.tsx
+++ b/web/src/app/forums/components/topic-list.tsx
@@ -1,0 +1,49 @@
+import { ForumTopic } from "../topics";
+
+function formatReplies(replies: number): string {
+  return replies.toLocaleString("en-GB");
+}
+
+type ForumTopicListProps = {
+  topics: ForumTopic[];
+};
+
+export function ForumTopicList({ topics }: ForumTopicListProps) {
+  return (
+    <div className="space-y-4">
+      {topics.map((topic) => (
+        <article
+          key={`${topic.title}-${topic.lastActivity}`}
+          className="group rounded-xl border border-slate-200 bg-white p-5 shadow-sm transition hover:border-blue-400 hover:shadow-md"
+        >
+          <div className="flex flex-wrap items-start gap-2">
+            {topic.pinned && (
+              <span className="inline-flex items-center rounded-full bg-amber-100 px-2.5 py-1 text-xs font-semibold text-amber-700">
+                Pinned
+              </span>
+            )}
+            {topic.tags?.map((tag) => (
+              <span
+                key={tag}
+                className="inline-flex items-center rounded-full bg-slate-100 px-2.5 py-1 text-xs font-medium text-slate-600"
+              >
+                #{tag}
+              </span>
+            ))}
+          </div>
+
+          <div className="mt-3 space-y-2">
+            <h3 className="text-lg font-semibold text-slate-900 group-hover:text-blue-600">{topic.title}</h3>
+            <p className="text-sm text-slate-600">{topic.excerpt}</p>
+          </div>
+
+          <div className="mt-4 flex flex-wrap items-center gap-3 text-xs text-slate-500">
+            <span>{formatReplies(topic.replies)} replies</span>
+            <span className="hidden h-1 w-1 rounded-full bg-slate-300 sm:inline" />
+            <span>Last activity {topic.lastActivity}</span>
+          </div>
+        </article>
+      ))}
+    </div>
+  );
+}

--- a/web/src/app/forums/page.tsx
+++ b/web/src/app/forums/page.tsx
@@ -1,0 +1,127 @@
+import Link from "next/link";
+import { apiGet } from "@/lib/api";
+import { GENERAL_FORUM_LIST } from "./topics";
+
+type AirportSummary = {
+  id: number;
+  icao: string;
+  iata: string;
+  name: string;
+  city: string;
+  country: string;
+};
+
+function formatAirportSubtitle(airport: AirportSummary): string {
+  const parts = [airport.city, airport.country].filter(Boolean);
+  return parts.join(", ");
+}
+
+export default async function ForumsLandingPage() {
+  let airports: AirportSummary[] = [];
+
+  try {
+    airports = await apiGet<AirportSummary[]>("/airports/");
+  } catch (error) {
+    console.error("Failed to load airport list", error);
+  }
+
+  const sortedAirports = [...airports].sort((a, b) => a.icao.localeCompare(b.icao));
+
+  return (
+    <main className="min-h-screen bg-slate-50 px-4 py-12">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-12">
+        <header className="space-y-6">
+          <div className="space-y-2">
+            <span className="inline-flex items-center rounded-full bg-blue-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-blue-700">
+              Community Forums
+            </span>
+            <h1 className="text-4xl font-bold text-slate-900">Connect with fellow spotters</h1>
+            <p className="max-w-2xl text-base text-slate-600">
+              Swap movement reports, coordinate meetups, and ask questions across our network of UK airports.
+              Start in a community hub below or jump straight into your local airport thread.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-3">
+            <Link
+              href="/login"
+              className="inline-flex items-center justify-center rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+            >
+              Sign in to start a thread
+            </Link>
+            <Link
+              href="/docs/community"
+              className="inline-flex items-center justify-center rounded-lg border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm transition hover:border-blue-400 hover:text-blue-600"
+            >
+              Review community guidelines
+            </Link>
+          </div>
+        </header>
+
+        <section className="space-y-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <h2 className="text-2xl font-semibold text-slate-900">Community hubs</h2>
+              <p className="text-sm text-slate-600">
+                Themed spaces for platform updates, live movement alerts, ATC chatter, and relaxed off-topic talk.
+              </p>
+            </div>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+            {GENERAL_FORUM_LIST.map((forum) => (
+              <Link
+                key={forum.slug}
+                href={`/forums/${forum.slug}`}
+                className="group flex h-full flex-col rounded-2xl border border-slate-200 bg-white p-5 shadow-sm transition hover:border-blue-400 hover:shadow-md"
+              >
+                <div className="space-y-2">
+                  <h3 className="text-lg font-semibold text-slate-900 group-hover:text-blue-600">{forum.title}</h3>
+                  <p className="text-sm text-slate-600">{forum.description}</p>
+                </div>
+                {forum.highlight && (
+                  <p className="mt-4 text-xs font-semibold uppercase tracking-wide text-blue-600">{forum.highlight}</p>
+                )}
+                <span className="mt-auto inline-flex items-center pt-4 text-sm font-semibold text-blue-600">
+                  Visit forum →
+                </span>
+              </Link>
+            ))}
+          </div>
+        </section>
+
+        <section className="space-y-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <h2 className="text-2xl font-semibold text-slate-900">Airport forums</h2>
+              <p className="text-sm text-slate-600">
+                Dedicated threads for each airport we currently cover—perfect for planning a spotting session or sharing local intel.
+              </p>
+            </div>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+            {sortedAirports.map((airport) => (
+              <Link
+                key={airport.icao}
+                href={`/forums/airports/${airport.icao.toLowerCase()}`}
+                className="group flex h-full flex-col rounded-2xl border border-slate-200 bg-white p-5 shadow-sm transition hover:border-blue-400 hover:shadow-md"
+              >
+                <div className="space-y-2">
+                  <div className="flex items-center justify-between text-xs font-semibold uppercase tracking-wide text-slate-500">
+                    <span>{airport.icao}</span>
+                    <span>{airport.iata}</span>
+                  </div>
+                  <h3 className="text-lg font-semibold text-slate-900 group-hover:text-blue-600">{airport.name}</h3>
+                  <p className="text-sm text-slate-600">{formatAirportSubtitle(airport)}</p>
+                </div>
+                <span className="mt-auto inline-flex items-center pt-4 text-sm font-semibold text-blue-600">
+                  Enter discussion →
+                </span>
+              </Link>
+            ))}
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/web/src/app/forums/topics.ts
+++ b/web/src/app/forums/topics.ts
@@ -1,0 +1,242 @@
+export type ForumTopic = {
+  title: string;
+  excerpt: string;
+  replies: number;
+  lastActivity: string;
+  tags?: string[];
+  pinned?: boolean;
+};
+
+export type ForumResource = {
+  title: string;
+  href: string;
+  description: string;
+};
+
+export type ForumCategoryContent = {
+  slug: string;
+  title: string;
+  description: string;
+  intro: string;
+  prompt: string;
+  topics: ForumTopic[];
+  guidelines: string[];
+  resources?: ForumResource[];
+  highlight?: string;
+};
+
+export const GENERAL_FORUMS: Record<string, ForumCategoryContent> = {
+  general: {
+    slug: "general",
+    title: "General Discussion",
+    description: "Announcements, feature ideas, and the latest news from the Plane Spotter team.",
+    intro:
+      "Chat with fellow aviation fans about community news, platform updates, trip reports, and anything that keeps the spotting community buzzing.",
+    prompt:
+      "Kick off a discussion about your latest project, share feedback for the team, or ask the community for travel tips.",
+    topics: [
+      {
+        title: "Welcome to the Plane Spotter community!",
+        excerpt:
+          "New around here? Introduce yourself, share your home airport, and let us know what you are most excited to spot this season.",
+        replies: 87,
+        lastActivity: "1 hour ago",
+        tags: ["introductions", "community"],
+        pinned: true,
+      },
+      {
+        title: "April platform roadmap and feedback thread",
+        excerpt:
+          "We have shipped live sector filtering and refreshed airport guides. Tell us what is working well and what you would like to see next.",
+        replies: 142,
+        lastActivity: "3 hours ago",
+        tags: ["roadmap", "feedback"],
+      },
+      {
+        title: "Favourite aviation podcasts right now?",
+        excerpt:
+          "Looking for new listening material for spotting trips. Drop your favourite ATC or airline podcasts and why you rate them.",
+        replies: 36,
+        lastActivity: "yesterday",
+        tags: ["media", "recommendations"],
+      },
+    ],
+    guidelines: [
+      "Be welcoming—reply to at least one new member every week to help them feel at home.",
+      "Keep feedback constructive and provide as much context as possible when suggesting improvements.",
+      "Use descriptive titles so other spotters can find useful discussions later on.",
+    ],
+    resources: [
+      {
+        title: "Product changelog",
+        href: "/docs/changelog",
+        description: "See the latest features and fixes as they ship.",
+      },
+      {
+        title: "Community code of conduct",
+        href: "/docs/community",
+        description: "Refresh the guidelines that keep our forums friendly and helpful.",
+      },
+    ],
+  },
+  sightings: {
+    slug: "sightings",
+    title: "Sightings & Alerts",
+    description: "Share rare visitors, daily movement logs, and heads-up alerts for your fellow spotters.",
+    intro:
+      "Log the movements you are catching, coordinate runs to the fence line, and help others keep track of special visitors in your region.",
+    prompt:
+      "Post your latest photo set, build collaborative movement logs, or give the community a heads-up about diversions.",
+    topics: [
+      {
+        title: "UK wide rare movement tracker",
+        excerpt:
+          "A rolling thread to capture one-off freighters, mil flights, and unusual bizjet activity across the UK.",
+        replies: 213,
+        lastActivity: "28 minutes ago",
+        tags: ["rare", "movements"],
+        pinned: true,
+      },
+      {
+        title: "Weekend cargo surge expected at EMA",
+        excerpt:
+          "Heads-up for the DHL A330F swap and an Emirates SkyCargo 777 positioning in on Saturday night.",
+        replies: 54,
+        lastActivity: "2 hours ago",
+        tags: ["cargo", "alerts"],
+      },
+      {
+        title: "Share your March military catches",
+        excerpt:
+          "From Voyagers to visiting NATO heavies—drop photos or logs of the movements you caught this month.",
+        replies: 91,
+        lastActivity: "yesterday",
+        tags: ["military", "photos"],
+      },
+    ],
+    guidelines: [
+      "Include timestamps, runway, and direction so others can triangulate the sighting.",
+      "Blur or redact sensitive callsigns if a movement should remain discreet.",
+      "Tag the airport or region in brackets at the start of your title for clarity.",
+    ],
+    resources: [
+      {
+        title: "Live map",
+        href: "/live",
+        description: "Track aircraft in real-time to confirm callsigns and routes.",
+      },
+      {
+        title: "Spotting logbook",
+        href: "/logbook",
+        description: "Record the movements you have captured and build your history.",
+      },
+    ],
+  },
+  "atc-chat": {
+    slug: "atc-chat",
+    title: "ATC Chat",
+    description: "Discuss phraseology, frequency changes, and real-world ops with fellow aviation communicators.",
+    intro:
+      "Swap techniques for catching clear audio, decode tricky transmissions, and keep track of recent procedure updates.",
+    prompt:
+      "Share your scanner setup, ask for help identifying callsigns, or post notes from recent ATC facility visits.",
+    topics: [
+      {
+        title: "Best handheld setup for busy multi-runway fields",
+        excerpt:
+          "Comparing antenna choices and filters when trying to cover Heathrow and Gatwick from the same location.",
+        replies: 68,
+        lastActivity: "45 minutes ago",
+        tags: ["equipment", "scanner"],
+      },
+      {
+        title: "Understanding London Control sector boundaries",
+        excerpt:
+          "Looking for a clear breakdown of the TC North sectors and when hand-offs typically occur for northbound departures.",
+        replies: 32,
+        lastActivity: "today",
+        tags: ["procedures", "london-control"],
+      },
+      {
+        title: "Phraseology changes coming with UK Phraseology Guide 2024",
+        excerpt:
+          "CAA draft guidance suggests updates to read-back requirements—anyone seen implementation timelines?",
+        replies: 21,
+        lastActivity: "2 days ago",
+        tags: ["regulations", "uk"],
+      },
+    ],
+    guidelines: [
+      "Keep discussions unclassified—do not share restricted or confidential recordings.",
+      "When quoting comms, include the frequency and approximate timestamp for context.",
+      "Link to primary sources (AIP updates, NOTAMs) wherever possible.",
+    ],
+    resources: [
+      {
+        title: "UK frequency directory",
+        href: "/frequencies",
+        description: "Browse verified tower, ground, and approach frequencies across the network.",
+      },
+      {
+        title: "ATC equipment discussions",
+        href: "/forums/sightings",
+        description: "Join the tech talk around antennas and receivers in the sightings community.",
+      },
+    ],
+    highlight: "Controllers and experienced monitors drop in regularly—tag them with @ATC to get insights on complex procedures.",
+  },
+  other: {
+    slug: "other",
+    title: "Off-Topic Lounge",
+    description: "Everything else—travel stories, photography kit, and the odd off-topic chat after a long day at the fence.",
+    intro:
+      "Relax with the community after the movements slow down. From trip planning to gear talk, keep things light-hearted and respectful.",
+    prompt:
+      "Start a casual thread about your latest adventure, organise meetups, or compare camera setups for low-light shooting.",
+    topics: [
+      {
+        title: "2024 spotting trip bucket list",
+        excerpt:
+          "Share the airports you are hoping to visit this year and tips for making the most of limited travel days.",
+        replies: 59,
+        lastActivity: "4 hours ago",
+        tags: ["travel", "planning"],
+      },
+      {
+        title: "Camera body upgrade advice for night shots",
+        excerpt:
+          "Looking to move on from a D750—what bodies are you loving for low-light departures?",
+        replies: 47,
+        lastActivity: "today",
+        tags: ["photography", "equipment"],
+      },
+      {
+        title: "Show us your aviation art",
+        excerpt:
+          "Whether it is models, prints, or digital art, post your favourite aviation-inspired creations.",
+        replies: 25,
+        lastActivity: "3 days ago",
+        tags: ["creative", "community"],
+      },
+    ],
+    guidelines: [
+      "Label non-aviation topics clearly so readers know what to expect.",
+      "Keep debate respectful—remember we gather here to unwind together.",
+      "Use the spoiler tag for large photo dumps to keep threads scroll-friendly.",
+    ],
+    resources: [
+      {
+        title: "Photography gear discussion",
+        href: "/forums/other",
+        description: "Share tips on lenses, backpacks, and editing workflows with fellow spotters.",
+      },
+      {
+        title: "Community meetups",
+        href: "/maps",
+        description: "Coordinate in-person trips using the shared spotting map and meet fellow members.",
+      },
+    ],
+  },
+};
+
+export const GENERAL_FORUM_LIST = Object.values(GENERAL_FORUMS);


### PR DESCRIPTION
## Summary
- add a forums landing page that introduces community hubs and links to each served airport
- curate topic metadata and shared rendering for category-specific discussion pages
- build airport-specific forum views that surface key frequencies, resources, and spotting highlights

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd80cbe2d0832495712813bb22afeb