### PR TITLE
Add shared navigation and unify page styling

### DIFF
--- a/web/src/app/airports/[id]/page.tsx
+++ b/web/src/app/airports/[id]/page.tsx
@@ -1,5 +1,6 @@
-import Link from "next/link";
+import { PageWrapper } from "@/app/components/page-wrapper";
 import { apiGet } from "@/lib/api";
+import Link from "next/link";
 
 type Frequency = {
   id: number;
@@ -52,11 +53,11 @@ const RESOURCE_CATEGORY_LABELS: Record<string, string> = {
 };
 
 const RESOURCE_CATEGORY_CLASSES: Record<string, string> = {
-  map: "bg-emerald-100 text-emerald-800",
-  guide: "bg-blue-100 text-blue-800",
-  official: "bg-slate-100 text-slate-800",
-  community: "bg-purple-100 text-purple-800",
-  video: "bg-orange-100 text-orange-800",
+  map: "bg-emerald-500/10 text-emerald-200",
+  guide: "bg-sky-500/10 text-sky-200",
+  official: "bg-slate-500/10 text-slate-200",
+  community: "bg-purple-500/10 text-purple-200",
+  video: "bg-orange-500/10 text-orange-200",
 };
 
 export default async function AirportDetailPage({ params }: PageProps) {
@@ -64,34 +65,49 @@ export default async function AirportDetailPage({ params }: PageProps) {
   const airport = await apiGet<Airport>(`/airports/${id}/`);
 
   return (
-    <main className="p-8 max-w-4xl mx-auto space-y-8">
-      <div className="space-y-2">
-        <Link href="/airports" className="text-sm text-blue-600 hover:underline">
+    <PageWrapper className="space-y-10">
+      <div className="space-y-3">
+        <Link
+          href="/airports"
+          className="inline-flex items-center text-xs font-semibold uppercase tracking-wide text-cyan-300 transition hover:text-cyan-200"
+        >
           ← Back to all airports
         </Link>
-        <h1 className="text-3xl font-bold">
+        <h1 className="text-3xl font-semibold text-white">
           {airport.icao} · {airport.name}
         </h1>
-        <p className="text-gray-600">
+        <p className="text-sm text-slate-300">
           {airport.city}, {airport.country}
         </p>
-        <p className="text-sm text-gray-500">
+        <p className="text-xs text-slate-400">
           Coordinates: {airport.lat.toFixed(4)}, {airport.lon.toFixed(4)}
         </p>
       </div>
 
-      <section>
-        <h2 className="text-2xl font-semibold mb-3">Frequencies</h2>
+      <section className="space-y-4">
+        <div>
+          <h2 className="text-2xl font-semibold text-white">Frequencies</h2>
+          <p className="mt-1 text-sm text-slate-300">
+            Active tower, approach, and ground channels to monitor during your spotting session.
+          </p>
+        </div>
         {airport.frequencies.length === 0 ? (
-          <p className="text-gray-600">No frequencies have been added yet.</p>
+          <p className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-slate-300">
+            No frequencies have been added yet.
+          </p>
         ) : (
           <div className="grid gap-4 md:grid-cols-2">
-            {airport.frequencies.map((freq) => (
-              <article key={freq.id} className="rounded-xl border bg-white p-4 shadow-sm">
-                <h3 className="text-lg font-semibold text-gray-900">{freq.service}</h3>
-                <p className="text-blue-600 font-mono text-sm">{Number(freq.mhz).toFixed(3)} MHz</p>
-                {freq.description ? (
-                  <p className="text-gray-600 mt-2 text-sm">{freq.description}</p>
+            {airport.frequencies.map((frequency) => (
+              <article
+                key={frequency.id}
+                className="rounded-2xl border border-white/10 bg-slate-900/60 p-5 shadow-lg shadow-cyan-500/5"
+              >
+                <h3 className="text-lg font-semibold text-white">{frequency.service}</h3>
+                <p className="font-mono text-sm text-cyan-300">
+                  {Number(frequency.mhz).toFixed(3)} MHz
+                </p>
+                {frequency.description ? (
+                  <p className="mt-2 text-sm text-slate-300">{frequency.description}</p>
                 ) : null}
               </article>
             ))}
@@ -99,21 +115,33 @@ export default async function AirportDetailPage({ params }: PageProps) {
         )}
       </section>
 
-      <section>
-        <h2 className="text-2xl font-semibold mb-3">Spotting Locations</h2>
+      <section className="space-y-4">
+        <div>
+          <h2 className="text-2xl font-semibold text-white">Spotting Locations</h2>
+          <p className="mt-1 text-sm text-slate-300">
+            Crowd-sourced vantage points with tips on lighting, access, and ideal movements to capture.
+          </p>
+        </div>
         {airport.spots.length === 0 ? (
-          <p className="text-gray-600">No spotting locations recorded yet. Be the first to add one!</p>
+          <p className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-slate-300">
+            No spotting locations recorded yet. Be the first to add one!
+          </p>
         ) : (
           <div className="space-y-4">
             {airport.spots.map((spot) => (
-              <article key={spot.id} className="rounded-xl border bg-white p-5 shadow-sm">
-                <h3 className="text-lg font-semibold text-gray-900">{spot.title}</h3>
-                {spot.description ? <p className="text-gray-700 mt-2">{spot.description}</p> : null}
-                <p className="text-sm text-gray-500 mt-3">
+              <article
+                key={spot.id}
+                className="rounded-2xl border border-white/10 bg-slate-900/60 p-5 shadow-lg shadow-cyan-500/5"
+              >
+                <h3 className="text-lg font-semibold text-white">{spot.title}</h3>
+                {spot.description ? (
+                  <p className="mt-2 text-sm leading-relaxed text-slate-300">{spot.description}</p>
+                ) : null}
+                <p className="mt-3 text-xs text-slate-400">
                   Coordinates: {spot.lat.toFixed(4)}, {spot.lon.toFixed(4)}
                 </p>
                 {spot.tips ? (
-                  <p className="mt-3 rounded-lg bg-blue-50 px-3 py-2 text-sm text-blue-700">
+                  <p className="mt-3 rounded-xl bg-cyan-500/10 px-3 py-2 text-sm text-cyan-200">
                     <strong className="font-semibold">Tips:</strong> {spot.tips}
                   </p>
                 ) : null}
@@ -123,30 +151,48 @@ export default async function AirportDetailPage({ params }: PageProps) {
         )}
       </section>
 
-      <section>
-        <h2 className="text-2xl font-semibold mb-3">Resources</h2>
+      <section className="space-y-4">
+        <div>
+          <h2 className="text-2xl font-semibold text-white">Resources</h2>
+          <p className="mt-1 text-sm text-slate-300">
+            Hand-picked guides, maps, and community links to help you plan your visit.
+          </p>
+        </div>
         {airport.resources.length === 0 ? (
-          <p className="text-gray-600">No resources listed yet.</p>
+          <p className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-slate-300">
+            No resources listed yet.
+          </p>
         ) : (
           <div className="space-y-4">
             {airport.resources.map((resource) => {
               const categoryLabel = RESOURCE_CATEGORY_LABELS[resource.category] || "Resource";
-              const categoryClasses = RESOURCE_CATEGORY_CLASSES[resource.category] || "bg-gray-100 text-gray-800";
+              const categoryClasses =
+                RESOURCE_CATEGORY_CLASSES[resource.category] || "bg-slate-500/10 text-slate-200";
 
               return (
-                <article key={resource.id} className="rounded-xl border bg-white p-5 shadow-sm">
-                  <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
-                    <h3 className="text-lg font-semibold text-gray-900">
-                      <a href={resource.url} target="_blank" rel="noopener noreferrer" className="hover:underline">
+                <article
+                  key={resource.id}
+                  className="rounded-2xl border border-white/10 bg-slate-900/60 p-5 shadow-lg shadow-cyan-500/5"
+                >
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                    <h3 className="text-lg font-semibold text-white">
+                      <a
+                        href={resource.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="transition hover:text-cyan-300 hover:underline"
+                      >
                         {resource.title}
                       </a>
                     </h3>
-                    <span className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold ${categoryClasses}`}>
+                    <span
+                      className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide ${categoryClasses}`}
+                    >
                       {categoryLabel}
                     </span>
                   </div>
                   {resource.description ? (
-                    <p className="text-gray-700 mt-2 text-sm leading-relaxed">{resource.description}</p>
+                    <p className="mt-2 text-sm leading-relaxed text-slate-300">{resource.description}</p>
                   ) : null}
                 </article>
               );
@@ -154,6 +200,6 @@ export default async function AirportDetailPage({ params }: PageProps) {
           </div>
         )}
       </section>
-    </main>
+    </PageWrapper>
   );
 }

--- a/web/src/app/airports/page.tsx
+++ b/web/src/app/airports/page.tsx
@@ -1,3 +1,4 @@
+import { PageWrapper } from "@/app/components/page-wrapper";
 import { apiGet } from "@/lib/api";
 import Link from "next/link";
 
@@ -14,23 +15,44 @@ export default async function AirportsPage() {
   const airports: Airport[] = await apiGet<Airport[]>("/airports/");
 
   return (
-    <main className="p-8 max-w-4xl mx-auto">
-      <h1 className="text-3xl font-bold mb-6">Airports</h1>
-      <ul className="space-y-4">
-        {airports.map((a) => (
-          <li
-            key={a.id}
-            className="p-4 border rounded-xl bg-white shadow-sm hover:shadow-md transition"
-          >
-            <Link href={`/airports/${a.id}`}>
-              <div className="font-semibold text-lg">
-                {a.icao} — {a.name}
+    <PageWrapper className="space-y-10">
+      <header className="space-y-4">
+        <div className="space-y-2">
+          <h1 className="text-3xl font-semibold tracking-tight text-white">Airports</h1>
+          <p className="max-w-2xl text-sm text-slate-300">
+            Explore curated spotting guides for every airfield we cover. Each airport profile highlights
+            on-the-ground insights, essential frequencies, and the community resources to plan your next
+            trip with confidence.
+          </p>
+        </div>
+      </header>
+
+      <ul className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+        {airports.map((airport) => (
+          <li key={airport.id}>
+            <Link
+              href={`/airports/${airport.id}`}
+              className="group flex h-full flex-col rounded-2xl border border-white/10 bg-white/5 p-5 shadow-lg shadow-cyan-500/5 transition hover:border-cyan-400/50 hover:bg-white/10"
+            >
+              <div className="flex items-center justify-between text-xs font-semibold uppercase tracking-wide text-slate-300">
+                <span>{airport.icao}</span>
+                <span className="text-slate-400">{airport.iata || "—"}</span>
               </div>
-              <div className="text-gray-600">{a.city}, {a.country}</div>
+              <div className="mt-3 space-y-1">
+                <h2 className="text-lg font-semibold text-white transition group-hover:text-cyan-300">
+                  {airport.name}
+                </h2>
+                <p className="text-sm text-slate-300">
+                  {airport.city}, {airport.country}
+                </p>
+              </div>
+              <span className="mt-auto inline-flex items-center pt-4 text-sm font-semibold text-cyan-300">
+                View guide →
+              </span>
             </Link>
           </li>
         ))}
       </ul>
-    </main>
+    </PageWrapper>
   );
 }

--- a/web/src/app/components/page-wrapper.tsx
+++ b/web/src/app/components/page-wrapper.tsx
@@ -1,0 +1,26 @@
+import type { ReactNode } from "react";
+
+type PageWrapperProps<T extends keyof JSX.IntrinsicElements> = {
+  /** HTML element to render. Defaults to `main` for semantic structure. */
+  as?: T;
+  /** Page content. */
+  children: ReactNode;
+  /** Additional Tailwind classes appended to the wrapper. */
+  className?: string;
+};
+
+const BASE_CLASSES =
+  "relative z-10 mx-auto w-full max-w-6xl px-6 pb-16 pt-24 lg:px-8";
+
+export function PageWrapper<T extends keyof JSX.IntrinsicElements = "main">({
+  as,
+  children,
+  className = "",
+}: PageWrapperProps<T>) {
+  const ComponentTag = (as ?? "main") as keyof JSX.IntrinsicElements;
+  const mergedClasses = className
+    ? `${BASE_CLASSES} ${className}`
+    : BASE_CLASSES;
+
+  return <ComponentTag className={mergedClasses}>{children}</ComponentTag>;
+}

--- a/web/src/app/components/site-header.tsx
+++ b/web/src/app/components/site-header.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useState } from "react";
+
+type NavItem = {
+  href: string;
+  label: string;
+};
+
+const NAV_ITEMS: NavItem[] = [
+  { href: "/airports", label: "Airports" },
+  { href: "/live", label: "Live Map" },
+  { href: "/frequencies", label: "Frequencies" },
+  { href: "/maps", label: "Maps" },
+  { href: "/logbook", label: "Logbook" },
+  { href: "/forums", label: "Community" },
+];
+
+function isActivePath(pathname: string | null, href: string) {
+  if (!pathname) {
+    return false;
+  }
+
+  if (href === "/") {
+    return pathname === "/";
+  }
+
+  return pathname === href || pathname.startsWith(`${href}/`);
+}
+
+export function SiteHeader() {
+  const pathname = usePathname();
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  const toggleMobile = () => setMobileOpen((value) => !value);
+  const closeMobile = () => setMobileOpen(false);
+
+  return (
+    <header className="sticky top-0 z-50 border-b border-white/10 bg-slate-950/85 backdrop-blur-xl">
+      <div className="mx-auto flex w-full max-w-6xl items-center justify-between px-6 py-4 lg:px-8">
+        <Link
+          href="/"
+          className="flex items-center gap-3 text-sm font-semibold tracking-tight text-white"
+          onClick={closeMobile}
+        >
+          <span className="relative flex h-10 w-10 items-center justify-center overflow-hidden rounded-2xl bg-cyan-500/15">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 32 32"
+              fill="none"
+              strokeWidth="1.8"
+              className="h-6 w-6 text-cyan-200"
+            >
+              <path
+                d="M3 17.5 16 12l13 5.5M16 12v8.5M10 29l6-8.5 6 8.5"
+                stroke="currentColor"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+            <span className="absolute inset-0 rounded-2xl border border-cyan-400/20" />
+          </span>
+          Plane Spotter
+        </Link>
+
+        <button
+          type="button"
+          className="inline-flex h-9 w-9 items-center justify-center rounded-xl border border-white/10 text-white transition hover:bg-white/10 lg:hidden"
+          onClick={toggleMobile}
+          aria-expanded={mobileOpen}
+          aria-controls="site-nav"
+        >
+          <span className="sr-only">Toggle navigation</span>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.8"
+            className="h-5 w-5"
+          >
+            {mobileOpen ? (
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18 18 6M6 6l12 12" />
+            ) : (
+              <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+            )}
+          </svg>
+        </button>
+
+        <nav
+          id="site-nav"
+          className="hidden items-center gap-8 text-sm font-medium text-slate-200 lg:flex"
+        >
+          {NAV_ITEMS.map((item) => {
+            const active = isActivePath(pathname, item.href);
+            return (
+              <Link
+                key={item.href}
+                href={item.href}
+                className={`transition hover:text-cyan-300 ${
+                  active ? "text-cyan-300" : "text-slate-300"
+                }`}
+              >
+                {item.label}
+              </Link>
+            );
+          })}
+          <Link
+            href="/login"
+            className="inline-flex items-center justify-center rounded-full border border-cyan-400/40 bg-cyan-500/10 px-4 py-1.5 text-xs font-semibold uppercase tracking-wide text-cyan-200 shadow-sm transition hover:border-cyan-300/60 hover:bg-cyan-400/20"
+          >
+            Login
+          </Link>
+        </nav>
+      </div>
+
+      <div
+        className={`lg:hidden ${
+          mobileOpen ? "max-h-96 border-t border-white/10" : "max-h-0 border-transparent"
+        } overflow-hidden bg-slate-950/95 backdrop-blur-xl transition-[max-height] duration-300 ease-in-out`}
+      >
+        <div className="space-y-1 px-6 py-4 text-sm text-slate-200">
+          {NAV_ITEMS.map((item) => {
+            const active = isActivePath(pathname, item.href);
+            return (
+              <Link
+                key={item.href}
+                href={item.href}
+                onClick={closeMobile}
+                className={`block rounded-xl px-3 py-2 transition hover:bg-white/5 ${
+                  active ? "bg-white/5 text-cyan-300" : "text-slate-200"
+                }`}
+              >
+                {item.label}
+              </Link>
+            );
+          })}
+          <Link
+            href="/login"
+            onClick={closeMobile}
+            className="mt-3 inline-flex w-full items-center justify-center rounded-xl border border-cyan-400/40 bg-cyan-500/10 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-cyan-200 transition hover:border-cyan-300/60 hover:bg-cyan-400/20"
+          >
+            Login
+          </Link>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/web/src/app/forums/page.tsx
+++ b/web/src/app/forums/page.tsx
@@ -1,5 +1,6 @@
-import Link from "next/link";
+import { PageWrapper } from "@/app/components/page-wrapper";
 import { apiGet } from "@/lib/api";
+import Link from "next/link";
 import { GENERAL_FORUM_LIST } from "./topics";
 
 type AirportSummary = {
@@ -28,100 +29,94 @@ export default async function ForumsLandingPage() {
   const sortedAirports = [...airports].sort((a, b) => a.icao.localeCompare(b.icao));
 
   return (
-    <main className="min-h-screen bg-slate-50 px-4 py-12">
-      <div className="mx-auto flex w-full max-w-6xl flex-col gap-12">
-        <header className="space-y-6">
-          <div className="space-y-2">
-            <span className="inline-flex items-center rounded-full bg-blue-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-blue-700">
-              Community Forums
-            </span>
-            <h1 className="text-4xl font-bold text-slate-900">Connect with fellow spotters</h1>
-            <p className="max-w-2xl text-base text-slate-600">
-              Swap movement reports, coordinate meetups, and ask questions across our network of UK airports.
-              Start in a community hub below or jump straight into your local airport thread.
-            </p>
-          </div>
-          <div className="flex flex-wrap gap-3">
+    <PageWrapper className="space-y-12">
+      <header className="space-y-6">
+        <div className="space-y-3">
+          <span className="inline-flex items-center rounded-full border border-cyan-400/40 bg-cyan-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-cyan-200">
+            Community Forums
+          </span>
+          <h1 className="text-4xl font-semibold text-white">Connect with fellow spotters</h1>
+          <p className="max-w-3xl text-base text-slate-300">
+            Swap movement reports, coordinate meetups, and ask questions across our network of UK airports. Start in a community
+            hub below or jump straight into your local airport thread.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-3">
+          <Link
+            href="/login"
+            className="inline-flex items-center justify-center rounded-full border border-cyan-400/40 bg-cyan-500/20 px-4 py-2 text-sm font-semibold uppercase tracking-wide text-cyan-100 transition hover:border-cyan-300/60 hover:bg-cyan-400/25"
+          >
+            Sign in to start a thread
+          </Link>
+          <Link
+            href="/docs/community"
+            className="inline-flex items-center justify-center rounded-full border border-white/10 bg-white/5 px-4 py-2 text-sm font-semibold text-slate-200 transition hover:border-cyan-400/40 hover:text-cyan-200"
+          >
+            Review community guidelines
+          </Link>
+        </div>
+      </header>
+
+      <section className="space-y-4">
+        <div>
+          <h2 className="text-2xl font-semibold text-white">Community hubs</h2>
+          <p className="text-sm text-slate-300">
+            Themed spaces for platform updates, live movement alerts, ATC chatter, and relaxed off-topic talk.
+          </p>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          {GENERAL_FORUM_LIST.map((forum) => (
             <Link
-              href="/login"
-              className="inline-flex items-center justify-center rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+              key={forum.slug}
+              href={`/forums/${forum.slug}`}
+              className="group flex h-full flex-col rounded-2xl border border-white/10 bg-white/5 p-5 text-slate-100 shadow-lg shadow-cyan-500/5 transition hover:border-cyan-400/50 hover:bg-white/10"
             >
-              Sign in to start a thread
+              <div className="space-y-2">
+                <h3 className="text-lg font-semibold text-white transition group-hover:text-cyan-300">{forum.title}</h3>
+                <p className="text-sm text-slate-200">{forum.description}</p>
+              </div>
+              {forum.highlight ? (
+                <p className="mt-4 text-xs font-semibold uppercase tracking-wide text-cyan-200">{forum.highlight}</p>
+              ) : null}
+              <span className="mt-auto inline-flex items-center pt-4 text-sm font-semibold text-cyan-300">
+                Visit forum →
+              </span>
             </Link>
+          ))}
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <div>
+          <h2 className="text-2xl font-semibold text-white">Airport forums</h2>
+          <p className="text-sm text-slate-300">
+            Dedicated threads for each airport we currently cover—perfect for planning a spotting session or sharing local intel.
+          </p>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+          {sortedAirports.map((airport) => (
             <Link
-              href="/docs/community"
-              className="inline-flex items-center justify-center rounded-lg border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm transition hover:border-blue-400 hover:text-blue-600"
+              key={airport.icao}
+              href={`/forums/airports/${airport.icao.toLowerCase()}`}
+              className="group flex h-full flex-col rounded-2xl border border-white/10 bg-white/5 p-5 text-slate-100 shadow-lg shadow-cyan-500/5 transition hover:border-cyan-400/50 hover:bg-white/10"
             >
-              Review community guidelines
+              <div className="space-y-2">
+                <div className="flex items-center justify-between text-xs font-semibold uppercase tracking-wide text-slate-300">
+                  <span>{airport.icao}</span>
+                  <span>{airport.iata}</span>
+                </div>
+                <h3 className="text-lg font-semibold text-white transition group-hover:text-cyan-300">{airport.name}</h3>
+                <p className="text-sm text-slate-200">{formatAirportSubtitle(airport)}</p>
+              </div>
+              <span className="mt-auto inline-flex items-center pt-4 text-sm font-semibold text-cyan-300">
+                Enter discussion →
+              </span>
             </Link>
-          </div>
-        </header>
-
-        <section className="space-y-4">
-          <div className="flex items-center justify-between">
-            <div>
-              <h2 className="text-2xl font-semibold text-slate-900">Community hubs</h2>
-              <p className="text-sm text-slate-600">
-                Themed spaces for platform updates, live movement alerts, ATC chatter, and relaxed off-topic talk.
-              </p>
-            </div>
-          </div>
-
-          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-            {GENERAL_FORUM_LIST.map((forum) => (
-              <Link
-                key={forum.slug}
-                href={`/forums/${forum.slug}`}
-                className="group flex h-full flex-col rounded-2xl border border-slate-200 bg-white p-5 shadow-sm transition hover:border-blue-400 hover:shadow-md"
-              >
-                <div className="space-y-2">
-                  <h3 className="text-lg font-semibold text-slate-900 group-hover:text-blue-600">{forum.title}</h3>
-                  <p className="text-sm text-slate-600">{forum.description}</p>
-                </div>
-                {forum.highlight && (
-                  <p className="mt-4 text-xs font-semibold uppercase tracking-wide text-blue-600">{forum.highlight}</p>
-                )}
-                <span className="mt-auto inline-flex items-center pt-4 text-sm font-semibold text-blue-600">
-                  Visit forum →
-                </span>
-              </Link>
-            ))}
-          </div>
-        </section>
-
-        <section className="space-y-4">
-          <div className="flex items-center justify-between">
-            <div>
-              <h2 className="text-2xl font-semibold text-slate-900">Airport forums</h2>
-              <p className="text-sm text-slate-600">
-                Dedicated threads for each airport we currently cover—perfect for planning a spotting session or sharing local intel.
-              </p>
-            </div>
-          </div>
-
-          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-            {sortedAirports.map((airport) => (
-              <Link
-                key={airport.icao}
-                href={`/forums/airports/${airport.icao.toLowerCase()}`}
-                className="group flex h-full flex-col rounded-2xl border border-slate-200 bg-white p-5 shadow-sm transition hover:border-blue-400 hover:shadow-md"
-              >
-                <div className="space-y-2">
-                  <div className="flex items-center justify-between text-xs font-semibold uppercase tracking-wide text-slate-500">
-                    <span>{airport.icao}</span>
-                    <span>{airport.iata}</span>
-                  </div>
-                  <h3 className="text-lg font-semibold text-slate-900 group-hover:text-blue-600">{airport.name}</h3>
-                  <p className="text-sm text-slate-600">{formatAirportSubtitle(airport)}</p>
-                </div>
-                <span className="mt-auto inline-flex items-center pt-4 text-sm font-semibold text-blue-600">
-                  Enter discussion →
-                </span>
-              </Link>
-            ))}
-          </div>
-        </section>
-      </div>
-    </main>
+          ))}
+        </div>
+      </section>
+    </PageWrapper>
   );
 }

--- a/web/src/app/frequencies/page.tsx
+++ b/web/src/app/frequencies/page.tsx
@@ -1,3 +1,4 @@
+import { PageWrapper } from "@/app/components/page-wrapper";
 import Link from "next/link";
 
 const methodology = [
@@ -58,62 +59,66 @@ const exchanges = [
 
 export default function FrequenciesPage() {
   return (
-    <main className="min-h-screen bg-slate-100 px-6 py-12">
-      <div className="mx-auto flex max-w-5xl flex-col gap-10">
-        <header className="text-center">
-          <h1 className="text-4xl font-bold text-slate-900">ATC Communication Guide</h1>
-          <p className="mt-4 text-lg text-slate-600">
-            Understand how Air Traffic Control orchestrates safe aircraft movement and what
-            common radio telephony (RTF) calls mean before you tune in.
-          </p>
-        </header>
+    <PageWrapper className="space-y-12">
+      <header className="space-y-4 text-center">
+        <h1 className="text-4xl font-semibold tracking-tight text-white">ATC Communication Guide</h1>
+        <p className="mx-auto max-w-2xl text-base text-slate-300">
+          Understand how Air Traffic Control orchestrates safe aircraft movement and what common radio telephony (RTF)
+          calls mean before you tune in.
+        </p>
+      </header>
 
-        <section className="rounded-2xl bg-white p-8 shadow-md">
-          <h2 className="text-2xl font-semibold text-slate-900">ATC Methodology</h2>
-          <p className="mt-2 text-slate-600">
-            Controllers coordinate flights through a series of specialized positions. Each
-            role focuses on a specific phase of flight, ensuring clear responsibilities and
-            consistent separation standards.
+      <section className="space-y-6 rounded-3xl border border-white/10 bg-slate-900/60 p-8 shadow-xl shadow-cyan-500/5">
+        <div className="space-y-2">
+          <h2 className="text-2xl font-semibold text-white">ATC Methodology</h2>
+          <p className="text-sm text-slate-300">
+            Controllers coordinate flights through a series of specialised positions. Each role focuses on a specific phase
+            of flight, ensuring clear responsibilities and consistent separation standards.
           </p>
-          <div className="mt-6 grid gap-6 md:grid-cols-2">
-            {methodology.map((item) => (
-              <article key={item.title} className="rounded-xl border border-slate-200 p-6">
-                <h3 className="text-xl font-semibold text-slate-800">{item.title}</h3>
-                <p className="mt-2 text-slate-600">{item.description}</p>
-              </article>
-            ))}
-          </div>
-        </section>
+        </div>
+        <div className="grid gap-4 md:grid-cols-2">
+          {methodology.map((item) => (
+            <article
+              key={item.title}
+              className="rounded-2xl border border-white/10 bg-white/5 p-5 text-left text-sm text-slate-200 transition hover:border-cyan-400/40 hover:bg-white/10"
+            >
+              <h3 className="text-lg font-semibold text-white">{item.title}</h3>
+              <p className="mt-2 text-sm leading-relaxed text-slate-200">{item.description}</p>
+            </article>
+          ))}
+        </div>
+      </section>
 
-        <section className="rounded-2xl bg-white p-8 shadow-md">
-          <h2 className="text-2xl font-semibold text-slate-900">Decoding RTF Exchanges</h2>
-          <p className="mt-2 text-slate-600">
-            Radio calls follow a predictable rhythm. Learning the intent behind each
-            exchange helps you follow the story in real time and anticipate what comes next.
+      <section className="space-y-6 rounded-3xl border border-white/10 bg-slate-900/60 p-8 shadow-xl shadow-cyan-500/5">
+        <div className="space-y-2">
+          <h2 className="text-2xl font-semibold text-white">Decoding RTF Exchanges</h2>
+          <p className="text-sm text-slate-300">
+            Radio calls follow a predictable rhythm. Learning the intent behind each exchange helps you follow the story in
+            real time and anticipate what comes next.
           </p>
-          <div className="mt-6 grid gap-6 md:grid-cols-2">
-            {exchanges.map((item) => (
-              <article key={item.call} className="rounded-xl border border-slate-200 p-6">
-                <h3 className="text-xl font-semibold text-slate-800">{item.call}</h3>
-                <p className="mt-2 text-slate-600">{item.meaning}</p>
-              </article>
-            ))}
-          </div>
-        </section>
+        </div>
+        <div className="grid gap-4 md:grid-cols-2">
+          {exchanges.map((item) => (
+            <article
+              key={item.call}
+              className="rounded-2xl border border-white/10 bg-white/5 p-5 text-left text-sm text-slate-200 transition hover:border-cyan-400/40 hover:bg-white/10"
+            >
+              <h3 className="text-lg font-semibold text-white">{item.call}</h3>
+              <p className="mt-2 text-sm leading-relaxed text-slate-200">{item.meaning}</p>
+            </article>
+          ))}
+        </div>
+      </section>
 
-        <section className="text-center text-sm text-slate-500">
-          <p>
-            Looking for live audio? Check our curated frequency list and streaming
-            resources.
-          </p>
-          <Link
-            href="/maps"
-            className="mt-3 inline-block rounded-full bg-blue-600 px-5 py-2 text-sm font-medium text-white shadow hover:bg-blue-700"
-          >
-            Explore Nearby Frequencies
-          </Link>
-        </section>
-      </div>
-    </main>
+      <section className="text-center text-sm text-slate-300">
+        <p>Looking for live audio? Check our curated frequency list and streaming resources.</p>
+        <Link
+          href="/maps"
+          className="mt-4 inline-flex items-center justify-center rounded-full border border-cyan-400/40 bg-cyan-500/10 px-5 py-2 text-sm font-semibold text-cyan-200 transition hover:border-cyan-300/60 hover:bg-cyan-400/20"
+        >
+          Explore Nearby Frequencies
+        </Link>
+      </section>
+    </PageWrapper>
   );
 }

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "maplibre-gl/dist/maplibre-gl.css";
 import "./globals.css";
+import { SiteHeader } from "./components/site-header";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -28,7 +29,17 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} bg-slate-950 text-slate-100 antialiased`}
       >
-        {children}
+        <div className="relative min-h-screen">
+          <div className="pointer-events-none absolute inset-0 -z-10">
+            <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.18),_transparent_55%)]" />
+            <div className="absolute inset-0 bg-[linear-gradient(125deg,rgba(15,118,110,0.12)_0%,transparent_45%,rgba(37,99,235,0.14)_100%)]" />
+            <div className="absolute inset-0 bg-gradient-to-b from-slate-950 via-slate-950/90 to-slate-950" />
+          </div>
+
+          <SiteHeader />
+
+          {children}
+        </div>
       </body>
     </html>
   );

--- a/web/src/app/live/page.tsx
+++ b/web/src/app/live/page.tsx
@@ -229,9 +229,9 @@ export default function LiveAdsbPage() {
   }, [lastUpdated]);
 
   return (
-    <main className="relative min-h-screen bg-[#020c19] text-sky-100">
+    <main className="relative min-h-screen bg-[#020c19] pb-10 pt-24 text-sky-100">
       <div className="pointer-events-none absolute inset-0 bg-[url('/textures/aviation-chart.svg')] bg-cover opacity-20" />
-      <div className="relative z-10 flex min-h-screen flex-col gap-6 px-4 pb-10 pt-6 lg:flex-row lg:px-8">
+      <div className="relative z-10 flex min-h-[calc(100vh-6rem)] flex-col gap-6 px-4 lg:flex-row lg:px-8">
         <section className="flex-1 rounded-3xl border border-sky-900/40 bg-slate-950/50 p-6 shadow-2xl shadow-sky-900/40 backdrop-blur-xl">
           <header className="mb-6 flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
             <div>

--- a/web/src/app/logbook/log/page.tsx
+++ b/web/src/app/logbook/log/page.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { FormEvent, useEffect, useMemo, useState } from "react";
 
+import { PageWrapper } from "@/app/components/page-wrapper";
 import { apiGet } from "@/lib/api";
 
 type FormState = {
@@ -131,7 +132,9 @@ export default function ManualLogbookPage() {
       } catch (loadError) {
         console.error("Failed to load aircraft details", loadError);
         if (!cancelled) {
-          setAircraftError("Unable to load aircraft details right now. Airline and type will remain blank.");
+          setAircraftError(
+            "Unable to load aircraft details right now. Airline and type will remain blank.",
+          );
           setAircraftLoaded(true);
         }
       }
@@ -230,189 +233,193 @@ export default function ManualLogbookPage() {
   };
 
   return (
-    <main className="min-h-screen bg-slate-50 py-10 px-4">
-      <div className="mx-auto w-full max-w-4xl space-y-8">
-        <header className="space-y-2">
-          <p className="text-sm text-blue-600">
-            <Link href="/logbook" className="hover:underline">
-              ← Back to fleet log
-            </Link>
-          </p>
-          <h1 className="text-3xl font-bold text-slate-900">Manual Sightings Log</h1>
-          <p className="text-slate-600">
-            Capture the aircraft you have spotted, including when and where you saw them. Entries
-            are stored locally on this device so you can build a personal spotting diary.
-          </p>
-        </header>
+    <PageWrapper className="space-y-10">
+      <header className="space-y-3">
+        <Link
+          href="/logbook"
+          className="inline-flex items-center text-xs font-semibold uppercase tracking-wide text-cyan-300 transition hover:text-cyan-200"
+        >
+          ← Back to fleet log
+        </Link>
+        <h1 className="text-3xl font-semibold text-white">Manual Sightings Log</h1>
+        <p className="max-w-2xl text-sm text-slate-300">
+          Capture the aircraft you have spotted, including when and where you saw them. Entries are stored locally on this device
+          so you can build a personal spotting diary.
+        </p>
+      </header>
 
-        <section className="rounded-2xl bg-white p-6 shadow-sm">
-          <form className="space-y-5" onSubmit={handleSubmit}>
-            <div className="grid gap-4 md:grid-cols-2">
-              <label className="flex flex-col text-sm font-medium text-slate-700">
-                Registration
-                <input
-                  value={form.registration}
-                  onChange={(event) => handleRegistrationChange(event.target.value)}
-                  className="mt-1 rounded-lg border border-slate-300 px-3 py-2 text-base uppercase tracking-wide text-slate-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
-                  placeholder="e.g. G-EZTH"
-                  required
-                />
-              </label>
+      <section className="rounded-3xl border border-white/10 bg-slate-900/70 p-8 shadow-2xl shadow-cyan-500/5">
+        <form className="space-y-6" onSubmit={handleSubmit}>
+          <div className="grid gap-4 md:grid-cols-2">
+            <label className="flex flex-col text-xs font-semibold uppercase tracking-wide text-slate-300">
+              Registration
+              <input
+                value={form.registration}
+                onChange={(event) => handleRegistrationChange(event.target.value)}
+                className="mt-2 rounded-xl border border-white/10 bg-slate-950/60 px-3 py-2 text-base uppercase tracking-wide text-slate-100 shadow-inner shadow-black/20 focus:border-cyan-400/60 focus:outline-none focus:ring-2 focus:ring-cyan-400/30"
+                placeholder="e.g. G-EZTH"
+                required
+              />
+            </label>
 
-              <div className="flex flex-col gap-2 text-sm font-medium text-slate-700">
-                <span>Airline</span>
-                <input
-                  value={form.airline || ""}
-                  readOnly
-                  className="rounded-lg border border-slate-200 bg-slate-100 px-3 py-2 text-base text-slate-600"
-                  placeholder={aircraftLoaded ? "Auto-filled from fleet data" : "Loading..."}
-                />
-              </div>
-
-              <div className="flex flex-col gap-2 text-sm font-medium text-slate-700">
-                <span>Aircraft type</span>
-                <input
-                  value={form.type || ""}
-                  readOnly
-                  className="rounded-lg border border-slate-200 bg-slate-100 px-3 py-2 text-base text-slate-600"
-                  placeholder={aircraftLoaded ? "Auto-filled from fleet data" : "Loading..."}
-                />
-              </div>
-
-              <label className="flex flex-col text-sm font-medium text-slate-700">
-                Location / Airport
-                <input
-                  value={form.location}
-                  onChange={(event) => setForm((prev) => ({ ...prev, location: event.target.value }))}
-                  className="mt-1 rounded-lg border border-slate-300 px-3 py-2 text-base text-slate-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
-                  placeholder="Where did you spot it?"
-                />
-              </label>
-
-              <label className="flex flex-col text-sm font-medium text-slate-700">
-                Date spotted
-                <input
-                  type="date"
-                  value={form.date}
-                  onChange={(event) => setForm((prev) => ({ ...prev, date: event.target.value }))}
-                  className="mt-1 rounded-lg border border-slate-300 px-3 py-2 text-base text-slate-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
-                  required
-                />
-              </label>
-
-              <label className="flex flex-col text-sm font-medium text-slate-700 md:col-span-2">
-                Notes
-                <textarea
-                  value={form.notes}
-                  onChange={(event) => setForm((prev) => ({ ...prev, notes: event.target.value }))}
-                  className="mt-1 min-h-[96px] rounded-lg border border-slate-300 px-3 py-2 text-base text-slate-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
-                  placeholder="Add any extra details from the sighting"
-                />
-              </label>
+            <div className="flex flex-col gap-2 text-xs font-semibold uppercase tracking-wide text-slate-300">
+              Airline
+              <input
+                value={form.airline || ""}
+                readOnly
+                className="rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-base text-slate-200"
+                placeholder={aircraftLoaded ? "Auto-filled from fleet data" : "Loading..."}
+              />
             </div>
 
-            <div className="space-y-2 text-sm text-slate-600">
-              {aircraftError ? (
-                <p className="rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-amber-800">
-                  {aircraftError}
-                </p>
-              ) : matchedAircraft ? (
-                <p className="rounded-lg border border-green-200 bg-green-50 px-3 py-2 text-green-800">
-                  Matched {matchedAircraft.airline || "airline"} · {matchedAircraft.type || "type"} from fleet data.
-                </p>
-              ) : aircraftLoaded && form.registration.trim() ? (
-                <p className="rounded-lg border border-blue-200 bg-blue-50 px-3 py-2 text-blue-800">
-                  No fleet data found for this registration. Airline and type will remain blank.
-                </p>
-              ) : null}
+            <div className="flex flex-col gap-2 text-xs font-semibold uppercase tracking-wide text-slate-300">
+              Aircraft type
+              <input
+                value={form.type || ""}
+                readOnly
+                className="rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-base text-slate-200"
+                placeholder={aircraftLoaded ? "Auto-filled from fleet data" : "Loading..."}
+              />
             </div>
 
-            {error && <p className="text-sm text-red-600">{error}</p>}
+            <label className="flex flex-col text-xs font-semibold uppercase tracking-wide text-slate-300">
+              Location / Airport
+              <input
+                value={form.location}
+                onChange={(event) => setForm((prev) => ({ ...prev, location: event.target.value }))}
+                className="mt-2 rounded-xl border border-white/10 bg-slate-950/60 px-3 py-2 text-base text-slate-100 shadow-inner shadow-black/20 focus:border-cyan-400/60 focus:outline-none focus:ring-2 focus:ring-cyan-400/30"
+                placeholder="Where did you spot it?"
+              />
+            </label>
 
-            <div className="flex justify-end">
-              <button
-                type="submit"
-                className="inline-flex items-center rounded-lg bg-blue-600 px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2"
-              >
-                Add to logbook
-              </button>
-            </div>
-          </form>
-        </section>
+            <label className="flex flex-col text-xs font-semibold uppercase tracking-wide text-slate-300">
+              Date spotted
+              <input
+                type="date"
+                value={form.date}
+                onChange={(event) => setForm((prev) => ({ ...prev, date: event.target.value }))}
+                className="mt-2 rounded-xl border border-white/10 bg-slate-950/60 px-3 py-2 text-base text-slate-100 shadow-inner shadow-black/20 focus:border-cyan-400/60 focus:outline-none focus:ring-2 focus:ring-cyan-400/30"
+                required
+              />
+            </label>
 
-        <section className="space-y-4">
-          <div className="flex flex-col gap-1">
-            <h2 className="text-2xl font-semibold text-slate-900">Your sightings</h2>
-            <p className="text-sm text-slate-600">
+            <label className="flex flex-col text-xs font-semibold uppercase tracking-wide text-slate-300 md:col-span-2">
+              Notes
+              <textarea
+                value={form.notes}
+                onChange={(event) => setForm((prev) => ({ ...prev, notes: event.target.value }))}
+                className="mt-2 min-h-[96px] rounded-xl border border-white/10 bg-slate-950/60 px-3 py-2 text-base text-slate-100 shadow-inner shadow-black/20 focus:border-cyan-400/60 focus:outline-none focus:ring-2 focus:ring-cyan-400/30"
+                placeholder="Add any extra details from the sighting"
+              />
+            </label>
+          </div>
+
+          <div className="space-y-2 text-sm text-slate-200">
+            {aircraftError ? (
+              <p className="rounded-xl border border-amber-400/40 bg-amber-500/10 px-3 py-2 text-amber-100">
+                {aircraftError}
+              </p>
+            ) : matchedAircraft ? (
+              <p className="rounded-xl border border-emerald-400/40 bg-emerald-500/10 px-3 py-2 text-emerald-100">
+                Matched {matchedAircraft.airline || "airline"} · {matchedAircraft.type || "type"} from fleet data.
+              </p>
+            ) : aircraftLoaded && form.registration.trim() ? (
+              <p className="rounded-xl border border-cyan-400/40 bg-cyan-500/10 px-3 py-2 text-cyan-100">
+                No fleet data found for this registration. Airline and type will remain blank.
+              </p>
+            ) : null}
+          </div>
+
+          {error && <p className="text-sm text-red-300">{error}</p>}
+
+          <div className="flex justify-end">
+            <button
+              type="submit"
+              className="inline-flex items-center rounded-full border border-cyan-400/40 bg-cyan-500/20 px-5 py-2 text-sm font-semibold uppercase tracking-wide text-cyan-100 transition hover:border-cyan-300/60 hover:bg-cyan-400/25"
+            >
+              Add to logbook
+            </button>
+          </div>
+        </form>
+      </section>
+
+      <section className="space-y-4 rounded-3xl border border-white/10 bg-slate-900/70 p-8 shadow-2xl shadow-cyan-500/5">
+        <div className="flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <h2 className="text-2xl font-semibold text-white">Your sightings</h2>
+            <p className="text-sm text-slate-300">
               {entries.length === 0
                 ? "No entries yet — start logging to build your personal spotting history."
                 : `Tracking ${entries.length} sighting${entries.length === 1 ? "" : "s"}.`}
             </p>
           </div>
+        </div>
 
-          {sortedEntries.length === 0 ? (
-            <p className="rounded-2xl border border-dashed border-slate-300 bg-white p-6 text-center text-slate-600">
-              Every time you log an aircraft, it will appear here.
-            </p>
-          ) : (
-            <ul className="space-y-4">
-              {sortedEntries.map((entry) => {
-                const formattedDate = entry.date
-                  ? new Intl.DateTimeFormat(undefined, {
-                      year: "numeric",
-                      month: "short",
-                      day: "numeric",
-                    }).format(new Date(entry.date))
-                  : "Date unknown";
+        {sortedEntries.length === 0 ? (
+          <p className="rounded-2xl border border-dashed border-white/20 bg-white/5 p-6 text-center text-sm text-slate-300">
+            Every time you log an aircraft, it will appear here.
+          </p>
+        ) : (
+          <ul className="space-y-4">
+            {sortedEntries.map((entry) => {
+              const formattedDate = entry.date
+                ? new Intl.DateTimeFormat(undefined, {
+                    year: "numeric",
+                    month: "short",
+                    day: "numeric",
+                  }).format(new Date(entry.date))
+                : "Date unknown";
 
-                return (
-                  <li key={entry.id} className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
-                    <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
-                      <div className="space-y-2">
-                        <h3 className="text-xl font-semibold text-slate-900">{entry.registration}</h3>
-                        <dl className="grid gap-1 text-sm text-slate-600">
-                          {entry.airline && (
-                            <div>
-                              <dt className="font-medium text-slate-500">Airline</dt>
-                              <dd>{entry.airline}</dd>
-                            </div>
-                          )}
-                          {entry.type && (
-                            <div>
-                              <dt className="font-medium text-slate-500">Type</dt>
-                              <dd>{entry.type}</dd>
-                            </div>
-                          )}
-                          {entry.location && (
-                            <div>
-                              <dt className="font-medium text-slate-500">Location</dt>
-                              <dd>{entry.location}</dd>
-                            </div>
-                          )}
+              return (
+                <li
+                  key={entry.id}
+                  className="rounded-2xl border border-white/10 bg-white/5 p-5 text-slate-100 shadow-lg shadow-cyan-500/5"
+                >
+                  <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+                    <div className="space-y-3">
+                      <h3 className="text-xl font-semibold text-white">{entry.registration}</h3>
+                      <dl className="grid gap-2 text-sm text-slate-200">
+                        {entry.airline && (
                           <div>
-                            <dt className="font-medium text-slate-500">Date spotted</dt>
-                            <dd>{formattedDate}</dd>
+                            <dt className="font-semibold text-slate-300">Airline</dt>
+                            <dd>{entry.airline}</dd>
                           </div>
-                        </dl>
-                        {entry.notes && <p className="text-sm text-slate-600">{entry.notes}</p>}
-                      </div>
-
-                      <button
-                        type="button"
-                        onClick={() => handleDelete(entry.id)}
-                        className="self-start rounded-lg border border-red-200 px-4 py-2 text-sm font-semibold text-red-600 transition hover:border-red-300 hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-red-200"
-                        aria-label={`Remove ${entry.registration} from logbook`}
-                      >
-                        Remove entry
-                      </button>
+                        )}
+                        {entry.type && (
+                          <div>
+                            <dt className="font-semibold text-slate-300">Type</dt>
+                            <dd>{entry.type}</dd>
+                          </div>
+                        )}
+                        {entry.location && (
+                          <div>
+                            <dt className="font-semibold text-slate-300">Location</dt>
+                            <dd>{entry.location}</dd>
+                          </div>
+                        )}
+                        <div>
+                          <dt className="font-semibold text-slate-300">Date spotted</dt>
+                          <dd>{formattedDate}</dd>
+                        </div>
+                      </dl>
+                      {entry.notes && <p className="text-sm text-slate-200">{entry.notes}</p>}
                     </div>
-                  </li>
-                );
-              })}
-            </ul>
-          )}
-        </section>
-      </div>
-    </main>
+
+                    <button
+                      type="button"
+                      onClick={() => handleDelete(entry.id)}
+                      className="self-start rounded-full border border-red-400/40 bg-red-500/10 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-red-200 transition hover:border-red-300/60 hover:bg-red-500/20"
+                      aria-label={`Remove ${entry.registration} from logbook`}
+                    >
+                      Remove entry
+                    </button>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </section>
+    </PageWrapper>
   );
 }

--- a/web/src/app/logbook/page.tsx
+++ b/web/src/app/logbook/page.tsx
@@ -1,5 +1,6 @@
-import Link from "next/link";
+import { PageWrapper } from "@/app/components/page-wrapper";
 import { apiGet } from "@/lib/api";
+import Link from "next/link";
 import SpottingLog from "./spotting-log";
 
 type Aircraft = {
@@ -20,33 +21,31 @@ export default async function LogbookPage() {
   }
 
   return (
-    <main className="min-h-screen bg-slate-50 py-10 px-4">
-      <div className="mx-auto w-full max-w-5xl space-y-6">
-        <header className="space-y-4">
-          <div className="space-y-2">
-            <h1 className="text-3xl font-bold text-slate-900">Spotting Log</h1>
-            <p className="text-slate-600">
-              Browse the latest fleet data and keep track of the aircraft you have spotted.
-              Filter by airline and aircraft type to focus your logbook on specific fleets.
-            </p>
-          </div>
+    <PageWrapper className="space-y-10">
+      <header className="space-y-4">
+        <div className="space-y-2">
+          <h1 className="text-3xl font-semibold text-white">Spotting Log</h1>
+          <p className="max-w-3xl text-sm text-slate-300">
+            Browse the latest fleet data and keep track of the aircraft you have spotted. Filter by airline and aircraft type to
+            focus your logbook on specific fleets.
+          </p>
+        </div>
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <p className="text-xs text-slate-400">
+            Prefer to capture detailed sightings? Use the manual logbook to record when and where you saw an aircraft.
+          </p>
+          <Link
+            href="/logbook/log"
+            className="inline-flex items-center justify-center rounded-full border border-cyan-400/40 bg-cyan-500/10 px-4 py-2 text-sm font-semibold text-cyan-200 transition hover:border-cyan-300/60 hover:bg-cyan-400/20"
+          >
+            Log a sighting manually
+          </Link>
+        </div>
+      </header>
 
-          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-            <p className="text-sm text-slate-600">
-              Prefer to capture detailed sightings? Use the manual logbook to record when and where
-              you saw an aircraft.
-            </p>
-            <Link
-              href="/logbook/log"
-              className="inline-flex items-center justify-center rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2"
-            >
-              Log a sighting manually
-            </Link>
-          </div>
-        </header>
-
+      <div className="rounded-3xl border border-white/10 bg-slate-900/60 p-4 shadow-xl shadow-cyan-500/5 sm:p-6">
         <SpottingLog initialAircraft={aircraft} />
       </div>
-    </main>
+    </PageWrapper>
   );
 }

--- a/web/src/app/logbook/spotting-log.tsx
+++ b/web/src/app/logbook/spotting-log.tsx
@@ -46,7 +46,7 @@ export default function SpottingLog({ initialAircraft }: SpottingLogProps) {
 
     window.localStorage.setItem(
       STORAGE_KEY,
-      JSON.stringify(Array.from(seenIds.values()))
+      JSON.stringify(Array.from(seenIds.values())),
     );
   }, [seenIds, storageReady]);
 
@@ -122,14 +122,14 @@ export default function SpottingLog({ initialAircraft }: SpottingLogProps) {
 
   return (
     <section className="space-y-6">
-      <div className="flex flex-col gap-4 rounded-2xl bg-white p-6 shadow-sm md:flex-row md:items-end md:justify-between">
+      <div className="flex flex-col gap-4 rounded-2xl border border-white/10 bg-white/5 p-6 text-slate-100 md:flex-row md:items-end md:justify-between">
         <div className="grid flex-1 gap-4 md:grid-cols-2">
-          <label className="flex flex-col text-sm font-medium text-slate-700">
+          <label className="flex flex-col text-sm font-medium text-slate-200">
             Airline
             <select
               value={airlineFilter}
               onChange={(event) => setAirlineFilter(event.target.value)}
-              className="mt-1 rounded-lg border border-slate-300 px-3 py-2 text-base text-slate-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+              className="mt-2 w-full rounded-xl border border-white/10 bg-slate-950/60 px-3 py-2 text-sm text-slate-100 shadow-inner shadow-black/20 focus:border-cyan-400/60 focus:outline-none focus:ring-2 focus:ring-cyan-400/30"
             >
               <option value="">All airlines</option>
               {airlines.map((airline) => (
@@ -140,12 +140,12 @@ export default function SpottingLog({ initialAircraft }: SpottingLogProps) {
             </select>
           </label>
 
-          <label className="flex flex-col text-sm font-medium text-slate-700">
+          <label className="flex flex-col text-sm font-medium text-slate-200">
             Aircraft type
             <select
               value={typeFilter}
               onChange={(event) => setTypeFilter(event.target.value)}
-              className="mt-1 rounded-lg border border-slate-300 px-3 py-2 text-base text-slate-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+              className="mt-2 w-full rounded-xl border border-white/10 bg-slate-950/60 px-3 py-2 text-sm text-slate-100 shadow-inner shadow-black/20 focus:border-cyan-400/60 focus:outline-none focus:ring-2 focus:ring-cyan-400/30 disabled:opacity-50"
               disabled={typeOptions.length === 0}
             >
               <option value="">All types</option>
@@ -158,9 +158,9 @@ export default function SpottingLog({ initialAircraft }: SpottingLogProps) {
           </label>
         </div>
 
-        <div className="rounded-lg bg-blue-50 px-4 py-3 text-sm text-blue-900">
-          <p className="font-semibold">Seen summary</p>
-          <p>
+        <div className="rounded-2xl border border-cyan-400/40 bg-cyan-500/10 px-4 py-3 text-sm text-cyan-100">
+          <p className="font-semibold uppercase tracking-wide">Seen summary</p>
+          <p className="text-xs text-cyan-100/80">
             {seenCount} of {initialAircraft.length} aircraft marked as seen
           </p>
         </div>
@@ -168,7 +168,7 @@ export default function SpottingLog({ initialAircraft }: SpottingLogProps) {
 
       <div className="grid gap-4">
         {filteredAircraft.length === 0 ? (
-          <p className="rounded-2xl border border-dashed border-slate-300 bg-white p-6 text-center text-slate-600">
+          <p className="rounded-2xl border border-dashed border-white/20 bg-white/5 p-6 text-center text-sm text-slate-300">
             No aircraft match the current filters. Try selecting a different airline or type.
           </p>
         ) : (
@@ -177,30 +177,32 @@ export default function SpottingLog({ initialAircraft }: SpottingLogProps) {
             return (
               <article
                 key={aircraft.id}
-                className={`flex flex-col justify-between gap-3 rounded-2xl border p-4 transition hover:shadow-md md:flex-row md:items-center ${
-                  isSeen ? "border-blue-400 bg-blue-50" : "border-slate-200 bg-white"
+                className={`flex flex-col justify-between gap-3 rounded-2xl border p-4 transition hover:border-cyan-400/50 hover:bg-cyan-500/10 md:flex-row md:items-center ${
+                  isSeen
+                    ? "border-cyan-400/50 bg-cyan-500/10 text-cyan-100"
+                    : "border-white/10 bg-slate-900/70 text-slate-100"
                 }`}
               >
                 <div>
-                  <h2 className="text-lg font-semibold text-slate-900">
+                  <h2 className="text-lg font-semibold">
                     {aircraft.registration}
                   </h2>
-                  <p className="text-sm text-slate-600">
+                  <p className="text-sm opacity-80">
                     {aircraft.airline || "Unknown airline"} · {aircraft.type || "Unknown type"}
                   </p>
                   {aircraft.country && (
-                    <p className="text-xs text-slate-500">Registered in {aircraft.country}</p>
+                    <p className="text-xs opacity-60">Registered in {aircraft.country}</p>
                   )}
                 </div>
 
-                <label className="flex items-center justify-end gap-2 text-sm font-medium text-slate-700">
+                <label className="flex items-center justify-end gap-2 text-sm font-medium">
                   <input
                     type="checkbox"
                     checked={isSeen}
                     onChange={() => toggleSeen(aircraft.id)}
-                    className="h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-blue-500"
+                    className="h-5 w-5 rounded border-white/30 bg-slate-950/60 text-cyan-400 focus:ring-cyan-300"
                   />
-                  Seen it!
+                  Mark as seen
                 </label>
               </article>
             );

--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -2,6 +2,8 @@
 
 import { FormEvent, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
+
+import { PageWrapper } from "@/app/components/page-wrapper";
 import { apiPost } from "@/lib/api";
 
 const TOKEN_STORAGE_KEY = "plane-spotter-token";
@@ -51,7 +53,7 @@ export default function LoginPage() {
         upcoming: true,
       },
     ],
-    []
+    [],
   );
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
@@ -78,119 +80,113 @@ export default function LoginPage() {
   };
 
   return (
-    <main className="min-h-screen bg-slate-950">
-      <div className="mx-auto flex min-h-screen max-w-6xl flex-col justify-center gap-16 px-6 py-16 lg:flex-row lg:items-center">
-        <section className="space-y-6 text-white lg:w-1/2">
-          <p className="inline-flex items-center gap-2 rounded-full bg-slate-900/80 px-4 py-1 text-sm font-medium text-blue-300 ring-1 ring-blue-500/40">
-            Plane Spotter Subscriptions
-          </p>
-          <h1 className="text-4xl font-semibold leading-tight sm:text-5xl">
-            Sign in to manage your flights and upcoming subscription benefits
-          </h1>
-          <p className="text-slate-300">
-            This account unlocks the current experience while laying the groundwork for
-            subscription tiers. Log in now and you will be ready when add-ons and premium
-            data packages roll out.
-          </p>
-          <div className="grid gap-4 sm:grid-cols-2">
-            {subscriptionTiers.map((tier) => (
-              <article
-                key={tier.name}
-                className="rounded-xl border border-slate-800 bg-slate-900/70 p-4 shadow-lg shadow-blue-900/20"
-              >
-                <h2 className="text-lg font-semibold text-white">{tier.name}</h2>
-                <p className="mt-2 text-sm text-slate-300">{tier.description}</p>
-                <p className="mt-4 text-xs font-medium uppercase tracking-wide text-blue-300">
-                  {tier.cta}
-                </p>
-                {tier.upcoming ? (
-                  <span className="mt-3 inline-flex w-fit items-center rounded-full bg-blue-500/20 px-3 py-1 text-xs font-semibold text-blue-200">
-                    Coming soon
-                  </span>
-                ) : null}
-              </article>
-            ))}
-          </div>
-        </section>
-
-        <section className="w-full rounded-3xl bg-white p-8 shadow-xl shadow-blue-900/20 lg:w-2/5">
-          <form className="space-y-6" onSubmit={handleSubmit}>
-            <div className="space-y-1">
-              <h2 className="text-2xl font-semibold text-slate-900">Welcome back</h2>
-              <p className="text-sm text-slate-600">
-                Use your Plane Spotter credentials to continue. We will connect this login to
-                subscription management soon.
-              </p>
-            </div>
-
-            <div className="space-y-4">
-              <label className="block" htmlFor="username">
-                <span className="text-sm font-medium text-slate-700">Email or username</span>
-                <input
-                  id="username"
-                  value={username}
-                  onChange={(event) => setUsername(event.target.value)}
-                  required
-                  autoComplete="username"
-                  placeholder="spotter@example.com"
-                  className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-slate-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
-                />
-              </label>
-
-              <label className="block" htmlFor="password">
-                <span className="text-sm font-medium text-slate-700">Password</span>
-                <input
-                  id="password"
-                  type="password"
-                  value={password}
-                  onChange={(event) => setPassword(event.target.value)}
-                  required
-                  autoComplete="current-password"
-                  placeholder="••••••••"
-                  className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-slate-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
-                />
-              </label>
-
-              <div className="flex items-center justify-between text-sm text-slate-600">
-                <label className="inline-flex items-center gap-2">
-                  <input
-                    type="checkbox"
-                    className="h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-blue-500"
-                    checked={rememberMe}
-                    onChange={(event) => setRememberMe(event.target.checked)}
-                  />
-                  Remember me on this device
-                </label>
-                <a className="font-medium text-blue-600 hover:text-blue-500" href="#">
-                  Forgot password?
-                </a>
-              </div>
-            </div>
-
-            {error ? (
-              <p className="text-sm text-red-600" role="alert">
-                {error}
-              </p>
-            ) : null}
-
-            <button
-              type="submit"
-              disabled={loading}
-              className="w-full rounded-lg bg-blue-600 py-2 text-white font-semibold shadow hover:bg-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-400 disabled:opacity-60"
+    <PageWrapper className="grid gap-12 pt-12 pb-20 lg:grid-cols-[1.1fr_0.9fr]">
+      <section className="space-y-6 rounded-3xl border border-white/10 bg-slate-900/70 p-8 text-white shadow-2xl shadow-cyan-500/5">
+        <p className="inline-flex items-center gap-2 rounded-full border border-cyan-400/40 bg-cyan-500/10 px-4 py-1 text-xs font-semibold uppercase tracking-wide text-cyan-200">
+          Plane Spotter Subscriptions
+        </p>
+        <h1 className="text-4xl font-semibold leading-tight sm:text-5xl">
+          Sign in to manage your flights and upcoming subscription benefits
+        </h1>
+        <p className="text-sm text-slate-300">
+          This account unlocks the current experience while laying the groundwork for subscription tiers. Log in now and you will
+          be ready when add-ons and premium data packages roll out.
+        </p>
+        <div className="grid gap-4 sm:grid-cols-2">
+          {subscriptionTiers.map((tier) => (
+            <article
+              key={tier.name}
+              className="rounded-2xl border border-white/10 bg-white/5 p-4 shadow-lg shadow-cyan-500/5"
             >
-              {loading ? "Signing in…" : "Sign in"}
-            </button>
+              <h2 className="text-lg font-semibold text-white">{tier.name}</h2>
+              <p className="mt-2 text-sm text-slate-200">{tier.description}</p>
+              <p className="mt-4 text-xs font-medium uppercase tracking-wide text-cyan-200">{tier.cta}</p>
+              {tier.upcoming ? (
+                <span className="mt-3 inline-flex w-fit items-center rounded-full border border-cyan-400/40 bg-cyan-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-cyan-200">
+                  Coming soon
+                </span>
+              ) : null}
+            </article>
+          ))}
+        </div>
+      </section>
 
-            <div className="rounded-lg border border-slate-200 bg-slate-50 p-4 text-sm text-slate-600">
-              <p className="font-medium text-slate-900">New to Plane Spotter?</p>
-              <p className="mt-1">
-                Start with the Essentials tier today and upgrade when subscriptions launch. Sign in
-                and head to the subscriptions tab to register your interest.
-              </p>
+      <section className="rounded-3xl border border-white/10 bg-white/5 p-8 text-slate-100 shadow-2xl shadow-cyan-500/5">
+        <form className="space-y-6" onSubmit={handleSubmit}>
+          <div className="space-y-1">
+            <h2 className="text-2xl font-semibold text-white">Welcome back</h2>
+            <p className="text-sm text-slate-300">
+              Use your Plane Spotter credentials to continue. We will connect this login to subscription management soon.
+            </p>
+          </div>
+
+          <div className="space-y-4">
+            <label className="block text-sm font-medium text-slate-200" htmlFor="username">
+              Email or username
+              <input
+                id="username"
+                value={username}
+                onChange={(event) => setUsername(event.target.value)}
+                required
+                autoComplete="username"
+                placeholder="spotter@example.com"
+                className="mt-2 w-full rounded-xl border border-white/10 bg-slate-950/60 px-3 py-2 text-slate-100 shadow-inner shadow-black/20 focus:border-cyan-400/60 focus:outline-none focus:ring-2 focus:ring-cyan-400/30"
+              />
+            </label>
+
+            <label className="block text-sm font-medium text-slate-200" htmlFor="password">
+              Password
+              <input
+                id="password"
+                type="password"
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+                required
+                autoComplete="current-password"
+                placeholder="••••••••"
+                className="mt-2 w-full rounded-xl border border-white/10 bg-slate-950/60 px-3 py-2 text-slate-100 shadow-inner shadow-black/20 focus:border-cyan-400/60 focus:outline-none focus:ring-2 focus:ring-cyan-400/30"
+              />
+            </label>
+
+            <div className="flex items-center justify-between text-xs text-slate-300">
+              <label className="inline-flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  className="h-4 w-4 rounded border-white/30 bg-slate-950/60 text-cyan-400 focus:ring-cyan-300"
+                  checked={rememberMe}
+                  onChange={(event) => setRememberMe(event.target.checked)}
+                />
+                Remember me on this device
+              </label>
+              <a className="font-medium text-cyan-200 transition hover:text-cyan-100" href="#">
+                Forgot password?
+              </a>
             </div>
-          </form>
-        </section>
-      </div>
-    </main>
+          </div>
+
+          {error ? (
+            <p className="rounded-xl border border-red-400/40 bg-red-500/10 px-4 py-2 text-sm text-red-200" role="alert">
+              {error}
+            </p>
+          ) : null}
+
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full rounded-full border border-cyan-400/40 bg-cyan-500/20 py-2 text-sm font-semibold uppercase tracking-wide text-cyan-100 transition hover:border-cyan-300/60 hover:bg-cyan-400/25 disabled:opacity-60"
+          >
+            {loading ? "Signing in…" : "Sign in"}
+          </button>
+
+          <div className="rounded-2xl border border-white/10 bg-slate-900/60 p-4 text-sm text-slate-200">
+            <p className="font-semibold text-white">New to Plane Spotter?</p>
+            <p className="mt-1 text-slate-300">
+              Start with the Essentials tier today and upgrade when subscriptions launch. Sign in and head to the subscriptions tab
+              to register your interest.
+            </p>
+          </div>
+        </form>
+      </section>
+    </PageWrapper>
   );
 }

--- a/web/src/app/maps/page.tsx
+++ b/web/src/app/maps/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef } from "react";
 import maplibregl from "maplibre-gl";
+import { PageWrapper } from "@/app/components/page-wrapper";
 
 export default function MapsPage() {
   const mapRef = useRef<HTMLDivElement>(null);
@@ -12,7 +13,7 @@ export default function MapsPage() {
     const map = new maplibregl.Map({
       container: mapRef.current,
       style: "https://demotiles.maplibre.org/style.json", // demo basemap
-      center: [-0.4543, 51.4700], // Heathrow
+      center: [-0.4543, 51.47], // Heathrow
       zoom: 9,
     });
 
@@ -20,9 +21,16 @@ export default function MapsPage() {
   }, []);
 
   return (
-    <main className="p-8">
-      <h1 className="text-3xl font-bold mb-4">Maps</h1>
-      <div ref={mapRef} className="w-full h-[600px] rounded-xl border shadow" />
-    </main>
+    <PageWrapper className="space-y-6">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-semibold text-white">Maps</h1>
+        <p className="text-sm text-slate-300">
+          Layer airfield diagrams, ground movements, and sectional data to plan your spotting sessions with confidence.
+        </p>
+      </header>
+      <div className="overflow-hidden rounded-3xl border border-white/10 bg-slate-900/60 shadow-2xl shadow-cyan-500/5">
+        <div ref={mapRef} className="h-[600px] w-full" />
+      </div>
+    </PageWrapper>
   );
 }

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -177,7 +177,7 @@ export default function Home() {
         <div className="absolute inset-0 bg-[linear-gradient(115deg,rgba(148,163,184,0.06)_0%,transparent_40%,rgba(15,118,110,0.08)_100%)]" />
       </div>
 
-      <div className="mx-auto flex w-full max-w-6xl flex-col gap-16 px-6 pb-20 pt-12 lg:px-8 lg:pt-16">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-16 px-6 pb-20 pt-24 lg:px-8 lg:pt-28">
         <header className="rounded-3xl border border-white/10 bg-white/5 p-6 backdrop-blur-xl lg:p-8">
           <div className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
             <div className="flex items-center gap-4">


### PR DESCRIPTION
## Summary
- add a sticky `SiteHeader` component and apply it in the root layout so navigation is consistent across pages
- introduce a reusable `PageWrapper` helper and restyle feature pages to share spacing, dark surfaces, and typography
- refresh login, logbook, live ADS-B, and content pages with the unified visual treatment while preserving their behaviours

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd82d140048324b714f52eec6fd1d6