### PR TITLE
Replace sectional chart tiles with OpenTopoMap

### DIFF
--- a/web/src/app/live/page.tsx
+++ b/web/src/app/live/page.tsx
@@ -19,11 +19,11 @@ const SECTIONAL_STYLE: StyleSpecification = {
     },
     sectional: {
       type: "raster",
-      tiles: [
-        "https://wms.chartbundle.com/tms/v1.0/sectional/{z}/{x}/{y}.png?opt=hires",
-      ],
+      tiles: ["https://tile.opentopomap.org/{z}/{x}/{y}.png"],
       tileSize: 256,
-      attribution: "Charts © ChartBundle / FAA",
+      attribution:
+        "Map data © OpenStreetMap contributors, SRTM | Map style: © OpenTopoMap (CC-BY-SA)",
+      maxzoom: 17,
     },
   },
   layers: [


### PR DESCRIPTION
## Summary
- swap the ChartBundle sectional tile source for an OpenTopoMap raster source
- update attribution and zoom limits so the map loads without tile errors

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd88258b2c8324addf03683e0aa078