### PR TITLE
Add Live ADS-B feed browser to SwiftUI app

### DIFF
--- a/ios/PlaneSpotter/PlaneSpotter.xcodeproj/project.pbxproj
+++ b/ios/PlaneSpotter/PlaneSpotter.xcodeproj/project.pbxproj
@@ -21,6 +21,9 @@
     C3674712E8E058248D65130B /* ErrorView.swift in Sources */ = { isa = PBXBuildFile; fileRef = 4089724706095F379021B3A0 /* ErrorView.swift */; };
     BAA43D424EAE5AE88F066513 /* AppEnvironment.swift in Sources */ = { isa = PBXBuildFile; fileRef = 7588B2FB879A58A5BD7E4634 /* AppEnvironment.swift */; };
     2F9957ABC6A45A59BDC1C681 /* AppEnvironment+Preview.swift in Sources */ = { isa = PBXBuildFile; fileRef = ACDDFD01F8DF55E9BEA70894 /* AppEnvironment+Preview.swift */; };
+    8F7E6D5C4B3A291817263544 /* LiveFleet.swift in Sources */ = { isa = PBXBuildFile; fileRef = E5E4C1B23A9D4F3E8C7564B2 /* LiveFleet.swift */; };
+    C3B2A1D0E9F8C7B6A5D4C3B2 /* LiveFleetViewModel.swift in Sources */ = { isa = PBXBuildFile; fileRef = D1C2B3A4F5E6D7C8B9A0F1E2 /* LiveFleetViewModel.swift */; };
+    B1A2C3D4E5F60718293A4B5C /* LiveFleetView.swift in Sources */ = { isa = PBXBuildFile; fileRef = F0E1D2C3B4A5968778695A4B /* LiveFleetView.swift */; };
     EFE877B9A7BF5C8493A151A7 /* Assets.xcassets in Resources */ = { isa = PBXBuildFile; fileRef = C0A54AFA5FC55138A4D4A2F6 /* Assets.xcassets */; };
     65643599E0995BF3984EEF2A /* Info.plist */ = { isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
     F2C1C00447315A6FA3FDD661 /* PlaneSpotterApp.swift */ = { isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaneSpotter/PlaneSpotterApp.swift; sourceTree = "<group>"; };
@@ -29,6 +32,7 @@
     2532A5C86B5D572B8E33B012 /* APIClient.swift */ = { isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaneSpotter/Networking/APIClient.swift; sourceTree = "<group>"; };
     B0E9DD5D5CF95460BE0F3A39 /* AirportListViewModel.swift */ = { isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaneSpotter/ViewModels/AirportListViewModel.swift; sourceTree = "<group>"; };
     6FDA9530B3FF5999BF3EDB2C /* AirportDetailViewModel.swift */ = { isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaneSpotter/ViewModels/AirportDetailViewModel.swift; sourceTree = "<group>"; };
+    D1C2B3A4F5E6D7C8B9A0F1E2 /* LiveFleetViewModel.swift */ = { isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaneSpotter/ViewModels/LiveFleetViewModel.swift; sourceTree = "<group>"; };
     2793A622C23A54B9B1770EE1 /* AirportListView.swift */ = { isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaneSpotter/Views/AirportListView.swift; sourceTree = "<group>"; };
     F38AAFF55EA4591CB02EEA0E /* AirportRowView.swift */ = { isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaneSpotter/Views/AirportRowView.swift; sourceTree = "<group>"; };
     FE634B60639B5588B47CE3A1 /* AirportDetailView.swift */ = { isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaneSpotter/Views/AirportDetailView.swift; sourceTree = "<group>"; };
@@ -36,10 +40,12 @@
     7897B666E43758EB97F765E3 /* PlaceholderView.swift */ = { isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaneSpotter/Views/PlaceholderView.swift; sourceTree = "<group>"; };
     DADF21BC74B85CB39F55B621 /* FrequencyGuideView.swift */ = { isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaneSpotter/Views/FrequencyGuideView.swift; sourceTree = "<group>"; };
     975C11955D8D5A26B2BC3AC3 /* AirportMapView.swift */ = { isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaneSpotter/Views/AirportMapView.swift; sourceTree = "<group>"; };
+    F0E1D2C3B4A5968778695A4B /* LiveFleetView.swift */ = { isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaneSpotter/Views/LiveFleetView.swift; sourceTree = "<group>"; };
     287D4DA01F115ED8A457531A /* LoadingView.swift */ = { isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaneSpotter/Components/LoadingView.swift; sourceTree = "<group>"; };
     4089724706095F379021B3A0 /* ErrorView.swift */ = { isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaneSpotter/Components/ErrorView.swift; sourceTree = "<group>"; };
     7588B2FB879A58A5BD7E4634 /* AppEnvironment.swift */ = { isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaneSpotter/Utilities/AppEnvironment.swift; sourceTree = "<group>"; };
     ACDDFD01F8DF55E9BEA70894 /* AppEnvironment+Preview.swift */ = { isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaneSpotter/Utilities/AppEnvironment+Preview.swift; sourceTree = "<group>"; };
+    E5E4C1B23A9D4F3E8C7564B2 /* LiveFleet.swift */ = { isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaneSpotter/Models/LiveFleet.swift; sourceTree = "<group>"; };
     C0A54AFA5FC55138A4D4A2F6 /* Assets.xcassets */ = { isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = PlaneSpotter/Assets.xcassets; sourceTree = "<group>"; };
     33D8A06D23175CCAA075A162 /* PlaneSpotter.app */ = { isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PlaneSpotter.app; sourceTree = BUILT_PRODUCTS_DIR; };
     
@@ -57,6 +63,7 @@
 AA616EE50AC15C21A92CAC2D /* Models */ = {
     isa = PBXGroup;
     children = (
+        E5E4C1B23A9D4F3E8C7564B2 /* LiveFleet.swift */,
         EF37EA1A1F8E5F3596A917BE /* Airport.swift */
     );
     path = Models;
@@ -89,7 +96,8 @@ AA616EE50AC15C21A92CAC2D /* Models */ = {
     isa = PBXGroup;
     children = (
         B0E9DD5D5CF95460BE0F3A39 /* AirportListViewModel.swift */,
-        6FDA9530B3FF5999BF3EDB2C /* AirportDetailViewModel.swift */
+        6FDA9530B3FF5999BF3EDB2C /* AirportDetailViewModel.swift */,
+        D1C2B3A4F5E6D7C8B9A0F1E2 /* LiveFleetViewModel.swift */
     );
     path = ViewModels;
     sourceTree = "<group>";
@@ -105,7 +113,8 @@ AA616EE50AC15C21A92CAC2D /* Models */ = {
         2D919A5171B95B958FC41B4F /* ResourceTagView.swift */,
         7897B666E43758EB97F765E3 /* PlaceholderView.swift */,
         DADF21BC74B85CB39F55B621 /* FrequencyGuideView.swift */,
-        975C11955D8D5A26B2BC3AC3 /* AirportMapView.swift */
+        975C11955D8D5A26B2BC3AC3 /* AirportMapView.swift */,
+        F0E1D2C3B4A5968778695A4B /* LiveFleetView.swift */
     );
     path = Views;
     sourceTree = "<group>";
@@ -161,6 +170,7 @@ AA616EE50AC15C21A92CAC2D /* Models */ = {
         1421403612055BCFA2E0E9EC,
         02DD320406E85FEFBA224C10,
         32186F235AE6519B907413BF,
+        C3B2A1D0E9F8C7B6A5D4C3B2,
         BF2A83B98D30532CB7835576,
         7D58661ABE2F55D0800DDD6E,
         3DDF64D63D1D517BA9DB4F19,
@@ -171,7 +181,9 @@ AA616EE50AC15C21A92CAC2D /* Models */ = {
         D50C61EDD0D85C72A1A3BB2D,
         C3674712E8E058248D65130B,
         BAA43D424EAE5AE88F066513,
-        2F9957ABC6A45A59BDC1C681
+        2F9957ABC6A45A59BDC1C681,
+        8F7E6D5C4B3A291817263544,
+        B1A2C3D4E5F60718293A4B5C
     );
     runOnlyForDeploymentPostprocessing = 0;
 };

--- a/ios/PlaneSpotter/PlaneSpotter/ContentView.swift
+++ b/ios/PlaneSpotter/PlaneSpotter/ContentView.swift
@@ -26,7 +26,7 @@ struct ContentView: View {
             HomeSection(title: "Airports", subtitle: "Spotting locations, reviews & photos", systemImage: "airplane.departure", destination: .airports, accent: .blue),
             HomeSection(title: "Frequencies", subtitle: "ATC communication primer", systemImage: "dot.radiowaves.left.and.right", destination: .frequencyGuide, accent: .purple),
             HomeSection(title: "Maps", subtitle: "Visualise airfields on a map", systemImage: "map", destination: .map, accent: .green),
-            HomeSection(title: "Live ADS-B", subtitle: "Track aircraft near favourite airports", systemImage: "radar", destination: .live, accent: .orange),
+            HomeSection(title: "Live ADS-B", subtitle: "Track active aircraft and filter by registration", systemImage: "radar", destination: .live, accent: .orange),
             HomeSection(title: "Logbook", subtitle: "Record aircraft you’ve spotted", systemImage: "note.text", destination: .logbook, accent: .teal),
             HomeSection(title: "Community", subtitle: "Forum, chat & badges", systemImage: "person.3", destination: .community, accent: .pink)
         ]
@@ -81,7 +81,8 @@ struct ContentView: View {
                     AirportMapView()
                         .environmentObject(environment)
                 case .live:
-                    PlaceholderView(title: "Live ADS-B", message: "Integration with a real-time ADS-B provider can surface nearby aircraft. Add your API credentials and rendering logic here.")
+                    LiveFleetView()
+                        .environmentObject(environment)
                 case .logbook:
                     PlaceholderView(title: "Logbook", message: "Connect to the /api/seen/ endpoint to sync spotted aircraft and maintain a personal logbook.")
                 case .community:

--- a/ios/PlaneSpotter/PlaneSpotter/Models/LiveFleet.swift
+++ b/ios/PlaneSpotter/PlaneSpotter/Models/LiveFleet.swift
@@ -1,0 +1,127 @@
+import Foundation
+
+struct LiveFleetResponse: Decodable, Equatable {
+    struct Filters: Decodable, Equatable {
+        let registration: String?
+        let country: String?
+    }
+
+    let count: Int
+    let results: [LiveAircraft]
+    let filters: Filters?
+}
+
+struct LiveAircraft: Decodable, Equatable {
+    let icao24: String
+    let registration: String
+    let manufacturer: String
+    let model: String
+    let typeCode: String
+    let icaoAircraftType: String
+    let operatorName: String
+    let operatorCallsign: String
+    let owner: String
+    let serialNumber: String
+    let built: String
+    let country: String
+
+    enum CodingKeys: String, CodingKey {
+        case icao24
+        case registration
+        case manufacturer
+        case model
+        case typeCode
+        case icaoAircraftType
+        case operatorName = "operator"
+        case operatorCallsign
+        case owner
+        case serialNumber
+        case built
+        case country
+    }
+}
+
+extension LiveAircraft {
+    var displayRegistration: String {
+        let trimmedRegistration = registration.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmedRegistration.isEmpty {
+            return trimmedRegistration.uppercased()
+        }
+        let hexValue = icao24.trimmingCharacters(in: .whitespacesAndNewlines)
+        return hexValue.isEmpty ? "Unknown" : hexValue.uppercased()
+    }
+
+    var airframeSummary: String? {
+        let manufacturerValue = manufacturer.trimmingCharacters(in: .whitespacesAndNewlines)
+        let modelValue = model.trimmingCharacters(in: .whitespacesAndNewlines)
+        let typeCodeValue = typeCode.trimmingCharacters(in: .whitespacesAndNewlines)
+        let icaoTypeValue = icaoAircraftType.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if !manufacturerValue.isEmpty || !modelValue.isEmpty {
+            return [manufacturerValue, modelValue].filter { !$0.isEmpty }.joined(separator: " ")
+        }
+        if !typeCodeValue.isEmpty {
+            return typeCodeValue
+        }
+        if !icaoTypeValue.isEmpty {
+            return icaoTypeValue
+        }
+        return nil
+    }
+
+    var operatorSummary: String? {
+        let operatorValue = operatorName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let callsignValue = operatorCallsign.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        let parts = [operatorValue, callsignValue].filter { !$0.isEmpty }
+        return parts.isEmpty ? nil : parts.joined(separator: " · ")
+    }
+
+    var ownerSummary: String? {
+        let ownerValue = owner.trimmingCharacters(in: .whitespacesAndNewlines)
+        return ownerValue.isEmpty ? nil : ownerValue
+    }
+
+    var metadataSummary: String? {
+        let hexValue = icao24.trimmingCharacters(in: .whitespacesAndNewlines)
+        let serialValue = serialNumber.trimmingCharacters(in: .whitespacesAndNewlines)
+        let builtValue = built.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        var parts: [String] = []
+        if !hexValue.isEmpty {
+            parts.append("ICAO24 \(hexValue.uppercased())")
+        }
+        if !serialValue.isEmpty {
+            parts.append("MSN \(serialValue)")
+        }
+        if !builtValue.isEmpty {
+            parts.append("Built \(builtValue)")
+        }
+        return parts.isEmpty ? nil : parts.joined(separator: " • ")
+    }
+
+    var countryDisplay: String? {
+        let countryValue = country.trimmingCharacters(in: .whitespacesAndNewlines)
+        return countryValue.isEmpty ? nil : countryValue
+    }
+
+    var stableIdentifier: String {
+        let hexValue = icao24.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !hexValue.isEmpty {
+            return hexValue.lowercased()
+        }
+        let registrationValue = registration.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !registrationValue.isEmpty {
+            return "reg-\(registrationValue.uppercased())"
+        }
+        let serialValue = serialNumber.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !serialValue.isEmpty {
+            return "serial-\(serialValue)"
+        }
+        let fallback = [manufacturer, model, owner, country]
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
+            .filter { !$0.isEmpty }
+            .joined(separator: "-")
+        return fallback.isEmpty ? "aircraft-unknown" : fallback
+    }
+}

--- a/ios/PlaneSpotter/PlaneSpotter/ViewModels/LiveFleetViewModel.swift
+++ b/ios/PlaneSpotter/PlaneSpotter/ViewModels/LiveFleetViewModel.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+@MainActor
+final class LiveFleetViewModel: ObservableObject {
+    struct Query: Equatable {
+        var registration: String?
+        var country: String?
+        var limit: Int
+
+        var hasFilters: Bool {
+            registration != nil || country != nil
+        }
+    }
+
+    enum State: Equatable {
+        case idle
+        case loading
+        case loaded(LiveFleetResponse)
+        case failed(String)
+    }
+
+    @Published private(set) var state: State = .idle
+    @Published private(set) var lastQuery: Query
+
+    private var apiClient: APIClient
+    private let minimumLimit: Int
+    let maximumLimit: Int
+
+    var minimumLimitValue: Int { minimumLimit }
+
+    init(apiClient: APIClient, defaultLimit: Int = 50, minimumLimit: Int = 10, maximumLimit: Int = 200) {
+        self.apiClient = apiClient
+        self.minimumLimit = minimumLimit
+        self.maximumLimit = maximumLimit
+        self.lastQuery = Query(registration: nil, country: nil, limit: defaultLimit)
+    }
+
+    func updateAPIClient(_ apiClient: APIClient) {
+        self.apiClient = apiClient
+    }
+
+    func loadFleet(registration: String?, country: String?, limit: Int) async {
+        let trimmedRegistration = registration?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedCountry = country?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let sanitizedRegistration = (trimmedRegistration?.isEmpty == false) ? trimmedRegistration : nil
+        let sanitizedCountry = (trimmedCountry?.isEmpty == false) ? trimmedCountry : nil
+        let sanitizedLimit = max(minimumLimit, min(limit, maximumLimit))
+
+        let query = Query(registration: sanitizedRegistration, country: sanitizedCountry, limit: sanitizedLimit)
+        lastQuery = query
+        state = .loading
+
+        do {
+            var queryItems = [URLQueryItem(name: "limit", value: String(query.limit))]
+            if let registration = query.registration {
+                queryItems.append(URLQueryItem(name: "registration", value: registration))
+            }
+            if let country = query.country {
+                queryItems.append(URLQueryItem(name: "country", value: country))
+            }
+
+            let response: LiveFleetResponse = try await apiClient.get("fleet/live/", queryItems: queryItems)
+            state = .loaded(response)
+        } catch {
+            if let apiError = error as? APIClient.APIError {
+                state = .failed(apiError.localizedDescription)
+            } else {
+                state = .failed(error.localizedDescription)
+            }
+        }
+    }
+}

--- a/ios/PlaneSpotter/PlaneSpotter/Views/LiveFleetView.swift
+++ b/ios/PlaneSpotter/PlaneSpotter/Views/LiveFleetView.swift
@@ -1,0 +1,191 @@
+import SwiftUI
+
+struct LiveFleetView: View {
+    @EnvironmentObject private var environment: AppEnvironment
+    @StateObject private var viewModel: LiveFleetViewModel
+
+    @State private var registration = ""
+    @State private var country = ""
+    @State private var limit: Int
+
+    init() {
+        let initialViewModel = LiveFleetViewModel(apiClient: AppEnvironment.preview.apiClient)
+        _viewModel = StateObject(wrappedValue: initialViewModel)
+        _limit = State(initialValue: initialViewModel.lastQuery.limit)
+    }
+
+    var body: some View {
+        content
+            .navigationTitle("Live ADS-B")
+            .task {
+                viewModel.updateAPIClient(environment.apiClient)
+                if case .idle = viewModel.state {
+                    await performLoad()
+                }
+            }
+            .refreshable {
+                await performLoad()
+            }
+    }
+
+    private var content: some View {
+        List {
+            filtersSection
+            resultsSection
+        }
+        .listStyle(.insetGrouped)
+    }
+
+    private var filtersSection: some View {
+        Section("Filters") {
+            TextField("Registration", text: $registration)
+                .textInputAutocapitalization(.characters)
+                .disableAutocorrection(true)
+                .onSubmit {
+                    Task { await performLoad() }
+                }
+            TextField("Country", text: $country)
+                .disableAutocorrection(true)
+                .onSubmit {
+                    Task { await performLoad() }
+                }
+            Stepper(value: $limit, in: viewModel.minimumLimitValue...viewModel.maximumLimit, step: 10) {
+                HStack {
+                    Text("Result limit")
+                    Spacer()
+                    Text("\(limit)")
+                        .font(.body.monospacedDigit())
+                        .foregroundStyle(.secondary)
+                }
+            }
+            Button {
+                Task { await performLoad() }
+            } label: {
+                Label("Apply Filters", systemImage: "arrow.triangle.2.circlepath")
+                    .font(.callout.weight(.semibold))
+            }
+            .buttonStyle(.borderedProminent)
+        } footer: {
+            Text(filtersSummary)
+        }
+    }
+
+    @ViewBuilder
+    private var resultsSection: some View {
+        Section("Results") {
+            switch viewModel.state {
+            case .idle, .loading:
+                HStack {
+                    Spacer()
+                    ProgressView("Loading fleet data…")
+                        .progressViewStyle(.circular)
+                    Spacer()
+                }
+                .padding(.vertical)
+            case let .failed(message):
+                VStack(spacing: 12) {
+                    Text("Unable to load fleet data")
+                        .font(.headline)
+                    Text(message)
+                        .font(.subheadline)
+                        .multilineTextAlignment(.center)
+                        .foregroundStyle(.secondary)
+                    Button {
+                        Task { await performLoad() }
+                    } label: {
+                        Label("Try Again", systemImage: "arrow.clockwise")
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical)
+            case let .loaded(response):
+                let total = response.count
+                Text("Found \(total) aircraft")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                if response.results.isEmpty {
+                    Text("No aircraft matched your filters. Try broadening the search.")
+                        .foregroundStyle(.secondary)
+                        .padding(.vertical)
+                } else {
+                    let sorted = response.results.sorted { lhs, rhs in
+                        lhs.displayRegistration < rhs.displayRegistration
+                    }
+                    ForEach(sorted, id: \.stableIdentifier) { aircraft in
+                        aircraftRow(for: aircraft)
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func aircraftRow(for aircraft: LiveAircraft) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .top) {
+                Text(aircraft.displayRegistration)
+                    .font(.headline)
+                Spacer()
+                if let country = aircraft.countryDisplay {
+                    Text(country)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            if let airframe = aircraft.airframeSummary {
+                Text(airframe)
+                    .font(.subheadline)
+            }
+            if let operatorSummary = aircraft.operatorSummary {
+                Text(operatorSummary)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+            if let owner = aircraft.ownerSummary, owner != (aircraft.operatorSummary ?? "") {
+                Text(owner)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+            if let metadata = aircraft.metadataSummary {
+                Text(metadata)
+                    .font(.caption.monospacedDigit())
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(.vertical, 8)
+    }
+
+    private var filtersSummary: String {
+        let registration = viewModel.lastQuery.registration?.uppercased()
+        let country = viewModel.lastQuery.country
+        var parts: [String] = []
+        if let registration, !registration.isEmpty {
+            parts.append("Registration contains \(registration)")
+        }
+        if let country, !country.isEmpty {
+            parts.append("Country matches \(country)")
+        }
+        let limit = viewModel.lastQuery.limit
+        let maxLimit = viewModel.maximumLimit
+        if limit >= maxLimit {
+            parts.append("Showing up to \(limit) aircraft (server max)")
+        } else {
+            parts.append("Showing up to \(limit) aircraft (max \(maxLimit))")
+        }
+        return parts.joined(separator: " · ")
+    }
+
+    @MainActor
+    private func performLoad() async {
+        viewModel.updateAPIClient(environment.apiClient)
+        await viewModel.loadFleet(
+            registration: registration,
+            country: country,
+            limit: limit
+        )
+        registration = viewModel.lastQuery.registration ?? ""
+        country = viewModel.lastQuery.country ?? ""
+        limit = viewModel.lastQuery.limit
+    }
+}

--- a/ios/README.md
+++ b/ios/README.md
@@ -9,7 +9,8 @@ This directory contains a native SwiftUI implementation of the Plane Spotter cli
 - Airport detail view that renders frequencies, spotting locations, and external resources with native styling and a MapKit preview.
 - Map view that plots all airports and lets you jump between them with animated camera transitions.
 - Frequency learning guide with rich text cards.
-- Placeholder screens for Live ADS-B, Logbook, and Community to highlight the API integration points that still need to be built.
+- Live ADS-B browser that streams the latest fleet data from the Django backend with filtering controls.
+- Placeholder screens for Logbook and Community to highlight the API integration points that still need to be built.
 
 ## Getting started
 
@@ -28,9 +29,13 @@ python manage.py runserver 0.0.0.0:8000
 
 Ensure your simulator can reach the backend host. When running inside Docker, replace `localhost` with your machine IP and update `API_BASE_URL` accordingly.
 
+### Live ADS-B feed configuration
+
+The Live ADS-B tab calls the `/api/fleet/live/` endpoint, which proxies the OpenSky aircraft metadata CSV. Override `AIRCRAFT_FEED_URL` in `backend/.env` if you prefer a different data source and ensure the Django server has network access.
+
 ## Extending the app
 
-- **Live ADS-B**: integrate with a live data provider (e.g. ADSBExchange) and present aircraft overlays in a dedicated view.
+- **Live ADS-B**: extend the list to include richer visuals such as a map overlay or sorting/grouping controls. The view already consumes the `/api/fleet/live/` endpoint and can be themed further.
 - **Logbook sync**: call the `/api/seen/` endpoint using authenticated requests to keep a local spotting log.
 - **Community**: wire up `/api/posts/`, `/api/comments/`, and `/api/badges/` to deliver social features.
 - **Offline caching**: wrap the networking layer with persistence to support offline browsing when at the airport.


### PR DESCRIPTION
## Summary
- add models and view model for decoding the `/api/fleet/live/` feed and managing filters
- build a SwiftUI `LiveFleetView` with search fields, limit control, and result presentation for the live ADS-B data
- swap the home navigation link to the new live feed view and update the iOS README with configuration guidance

## Testing
- not run (iOS-specific)


------
https://chatgpt.com/codex/tasks/task_e_68dd87fc804c83249442c3aec5c94931