### PR TITLE
Add airline fleet browser with logbook integration

### DIFF
--- a/web/src/app/components/site-header.tsx
+++ b/web/src/app/components/site-header.tsx
@@ -14,6 +14,7 @@ const NAV_ITEMS: NavItem[] = [
   { href: "/live", label: "Live Map" },
   { href: "/frequencies", label: "Frequencies" },
   { href: "/maps", label: "Maps" },
+  { href: "/fleets", label: "Fleets" },
   { href: "/logbook", label: "Logbook" },
   { href: "/forums", label: "Community" },
 ];

--- a/web/src/app/fleets/fleet-browser.tsx
+++ b/web/src/app/fleets/fleet-browser.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import { isAircraftSeen, useSeenAircraft } from "../logbook/use-seen-aircraft";
+
+type Aircraft = {
+  id: number;
+  registration: string;
+  type: string;
+  airline: string;
+  country: string;
+};
+
+type FleetBrowserProps = {
+  aircraft: Aircraft[];
+};
+
+function normaliseAirline(name: string | null | undefined) {
+  return name?.trim() || "Unassigned operator";
+}
+
+export default function FleetBrowser({ aircraft }: FleetBrowserProps) {
+  const { seenIds, toggleSeen } = useSeenAircraft();
+
+  const airlines = useMemo(() => {
+    const counts = new Map<string, number>();
+
+    aircraft.forEach((item) => {
+      const airline = normaliseAirline(item.airline);
+      counts.set(airline, (counts.get(airline) ?? 0) + 1);
+    });
+
+    return Array.from(counts.entries())
+      .sort((a, b) => a[0].localeCompare(b[0]))
+      .map(([name, count]) => ({ name, count }));
+  }, [aircraft]);
+
+  const [selectedAirline, setSelectedAirline] = useState(() => airlines[0]?.name ?? "");
+
+  useEffect(() => {
+    if (!selectedAirline && airlines.length > 0) {
+      setSelectedAirline(airlines[0]!.name);
+    }
+  }, [airlines, selectedAirline]);
+
+  useEffect(() => {
+    if (selectedAirline && !airlines.some((airline) => airline.name === selectedAirline)) {
+      setSelectedAirline(airlines[0]?.name ?? "");
+    }
+  }, [airlines, selectedAirline]);
+
+  const airlineFleet = useMemo(() => {
+    const scoped = aircraft.filter((item) => normaliseAirline(item.airline) === selectedAirline);
+
+    const groups = new Map<string, Aircraft[]>();
+    scoped.forEach((item) => {
+      const type = item.type?.trim() || "Unknown type";
+      const current = groups.get(type) ?? [];
+      current.push(item);
+      groups.set(type, current);
+    });
+
+    return Array.from(groups.entries())
+      .map(([type, items]) => ({
+        type,
+        items: items.sort((a, b) => a.registration.localeCompare(b.registration)),
+      }))
+      .sort((a, b) => a.type.localeCompare(b.type));
+  }, [aircraft, selectedAirline]);
+
+  const seenInAirline = useMemo(() => {
+    if (!selectedAirline) {
+      return 0;
+    }
+
+    return aircraft.reduce((count, item) => {
+      if (normaliseAirline(item.airline) !== selectedAirline) {
+        return count;
+      }
+      return count + (seenIds.has(item.id) ? 1 : 0);
+    }, 0);
+  }, [aircraft, selectedAirline, seenIds]);
+
+  if (airlines.length === 0) {
+    return (
+      <div className="rounded-3xl border border-dashed border-white/10 bg-white/5 p-10 text-center text-sm text-slate-300">
+        No fleet data is available yet. Check back once the database has been seeded.
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[260px,1fr]">
+      <aside className="space-y-4">
+        <div className="rounded-3xl border border-white/10 bg-slate-900/80 p-4">
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-300">Airlines</h2>
+          <p className="mt-1 text-xs text-slate-400">
+            Browse each carrier to see registrations and types available in the fleet.
+          </p>
+        </div>
+        <ul className="space-y-2">
+          {airlines.map((airline) => {
+            const active = airline.name === selectedAirline;
+            return (
+              <li key={airline.name}>
+                <button
+                  type="button"
+                  onClick={() => setSelectedAirline(airline.name)}
+                  className={`w-full rounded-2xl border px-4 py-3 text-left text-sm transition ${
+                    active
+                      ? "border-cyan-400/60 bg-cyan-500/10 text-cyan-100"
+                      : "border-white/10 bg-slate-900/70 text-slate-200 hover:border-cyan-400/40 hover:bg-cyan-500/5"
+                  }`}
+                >
+                  <span className="flex items-center justify-between">
+                    <span className="font-medium">{airline.name}</span>
+                    <span className="text-xs uppercase tracking-wide opacity-70">{airline.count}</span>
+                  </span>
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      </aside>
+
+      <section className="space-y-6">
+        {selectedAirline ? (
+          <header className="rounded-3xl border border-white/10 bg-slate-900/60 p-5 text-slate-100">
+            <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+              <div>
+                <h1 className="text-2xl font-semibold">{selectedAirline} fleet overview</h1>
+                <p className="text-sm text-slate-300/80">
+                  Registrations and aircraft types sourced from the Plane Spotter fleet database.
+                </p>
+              </div>
+              <div className="rounded-2xl border border-cyan-400/40 bg-cyan-500/10 px-4 py-3 text-right text-sm text-cyan-100">
+                <p className="font-semibold uppercase tracking-wide">Seen in this fleet</p>
+                <p className="text-xs text-cyan-100/80">
+                  {seenInAirline} of {airlineFleet.reduce((total, group) => total + group.items.length, 0)} aircraft
+                </p>
+              </div>
+            </div>
+          </header>
+        ) : null}
+
+        {selectedAirline ? (
+          airlineFleet.length === 0 ? (
+            <p className="rounded-3xl border border-dashed border-white/10 bg-white/5 p-6 text-center text-sm text-slate-300">
+              No aircraft found for this airline.
+            </p>
+          ) : (
+            airlineFleet.map((group) => (
+              <article
+                key={group.type}
+                className="space-y-4 rounded-3xl border border-white/10 bg-slate-950/70 p-5 text-slate-100 shadow-lg shadow-cyan-500/5"
+              >
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                  <div>
+                    <h2 className="text-lg font-semibold">{group.type}</h2>
+                    <p className="text-xs text-slate-300/80">
+                      {group.items.length} registration{group.items.length === 1 ? "" : "s"}
+                    </p>
+                  </div>
+                </div>
+
+                <div className="grid gap-3 md:grid-cols-2">
+                  {group.items.map((item) => {
+                    const seen = isAircraftSeen(seenIds, item.id);
+                    return (
+                      <div
+                        key={item.id}
+                        className={`flex items-center justify-between gap-3 rounded-2xl border px-4 py-3 text-sm transition ${
+                          seen
+                            ? "border-cyan-400/60 bg-cyan-500/10 text-cyan-100"
+                            : "border-white/10 bg-slate-900/70 text-slate-200 hover:border-cyan-400/40 hover:bg-cyan-500/5"
+                        }`}
+                      >
+                        <div>
+                          <p className="text-base font-semibold tracking-tight">{item.registration}</p>
+                          <p className="text-xs text-slate-300/80">
+                            {item.country ? `Registered in ${item.country}` : "Registration country unknown"}
+                          </p>
+                        </div>
+                        <button
+                          type="button"
+                          onClick={() => toggleSeen(item.id)}
+                          className={`inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-wide transition ${
+                            seen
+                              ? "border-cyan-300/70 bg-cyan-400/20 text-cyan-100"
+                              : "border-white/20 bg-white/5 text-slate-200 hover:border-cyan-300/60 hover:bg-cyan-500/10 hover:text-cyan-100"
+                          }`}
+                        >
+                          {seen ? (
+                            <>
+                              <span className="inline-block h-2 w-2 rounded-full bg-cyan-300" aria-hidden />
+                              Seen
+                            </>
+                          ) : (
+                            "Mark seen"
+                          )}
+                        </button>
+                      </div>
+                    );
+                  })}
+                </div>
+              </article>
+            ))
+          )
+        ) : (
+          <p className="rounded-3xl border border-dashed border-white/10 bg-white/5 p-6 text-center text-sm text-slate-300">
+            Select an airline from the list to browse its fleet.
+          </p>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/web/src/app/fleets/page.tsx
+++ b/web/src/app/fleets/page.tsx
@@ -1,0 +1,48 @@
+import { PageWrapper } from "@/app/components/page-wrapper";
+import { apiGet } from "@/lib/api";
+
+import FleetBrowser from "./fleet-browser";
+
+type Aircraft = {
+  id: number;
+  registration: string;
+  type: string;
+  airline: string;
+  country: string;
+};
+
+export const metadata = {
+  title: "Airline Fleets",
+  description: "Browse airline fleets and track the registrations you have already spotted.",
+};
+
+export default async function FleetsPage() {
+  let aircraft: Aircraft[] = [];
+
+  try {
+    aircraft = await apiGet<Aircraft[]>("/aircraft/");
+  } catch (error) {
+    console.error("Failed to load aircraft data", error);
+  }
+
+  return (
+    <PageWrapper className="space-y-10">
+      <header className="space-y-4">
+        <div className="space-y-2">
+          <h1 className="text-3xl font-semibold text-white">Airline Fleets</h1>
+          <p className="max-w-3xl text-sm text-slate-300">
+            Select a carrier to explore its active fleet. Registrations you have marked as seen in your spotting log are
+            highlighted automatically so you can focus on the next additions to your collection.
+          </p>
+        </div>
+        <p className="text-xs text-slate-400">
+          Fleet information is sourced from the Plane Spotter dataset and updates as the aircraft catalog grows.
+        </p>
+      </header>
+
+      <div className="rounded-3xl border border-white/10 bg-slate-900/60 p-4 shadow-xl shadow-cyan-500/5 sm:p-6">
+        <FleetBrowser aircraft={aircraft} />
+      </div>
+    </PageWrapper>
+  );
+}

--- a/web/src/app/logbook/spotting-log.tsx
+++ b/web/src/app/logbook/spotting-log.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect, useMemo, useState } from "react";
 
+import { useSeenAircraft } from "./use-seen-aircraft";
+
 type Aircraft = {
   id: number;
   registration: string;
@@ -14,41 +16,10 @@ type SpottingLogProps = {
   initialAircraft: Aircraft[];
 };
 
-const STORAGE_KEY = "plane-spotter/logbook-seen";
-
 export default function SpottingLog({ initialAircraft }: SpottingLogProps) {
   const [airlineFilter, setAirlineFilter] = useState<string>("");
   const [typeFilter, setTypeFilter] = useState<string>("");
-  const [seenIds, setSeenIds] = useState<Set<number>>(new Set());
-  const [storageReady, setStorageReady] = useState(false);
-
-  useEffect(() => {
-    if (typeof window === "undefined") {
-      return;
-    }
-
-    const stored = window.localStorage.getItem(STORAGE_KEY);
-    if (stored) {
-      try {
-        const parsed = JSON.parse(stored) as number[];
-        setSeenIds(new Set(parsed));
-      } catch (error) {
-        console.warn("Unable to parse spotting log storage", error);
-      }
-    }
-    setStorageReady(true);
-  }, []);
-
-  useEffect(() => {
-    if (!storageReady || typeof window === "undefined") {
-      return;
-    }
-
-    window.localStorage.setItem(
-      STORAGE_KEY,
-      JSON.stringify(Array.from(seenIds.values())),
-    );
-  }, [seenIds, storageReady]);
+  const { seenIds, toggleSeen } = useSeenAircraft();
 
   const airlines = useMemo(() => {
     const unique = new Set<string>();
@@ -107,18 +78,6 @@ export default function SpottingLog({ initialAircraft }: SpottingLogProps) {
   }, [airlineFilter, typeFilter, initialAircraft]);
 
   const seenCount = useMemo(() => seenIds.size, [seenIds]);
-
-  const toggleSeen = (id: number) => {
-    setSeenIds((prev) => {
-      const next = new Set(prev);
-      if (next.has(id)) {
-        next.delete(id);
-      } else {
-        next.add(id);
-      }
-      return next;
-    });
-  };
 
   return (
     <section className="space-y-6">

--- a/web/src/app/logbook/use-seen-aircraft.ts
+++ b/web/src/app/logbook/use-seen-aircraft.ts
@@ -1,0 +1,60 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const STORAGE_KEY = "plane-spotter/logbook-seen";
+
+export function useSeenAircraft() {
+  const [seenIds, setSeenIds] = useState<Set<number>>(() => new Set());
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      try {
+        const parsed = JSON.parse(stored) as number[];
+        setSeenIds(new Set(parsed));
+      } catch (error) {
+        console.warn("Unable to parse spotting log storage", error);
+      }
+    }
+    setReady(true);
+  }, []);
+
+  useEffect(() => {
+    if (!ready || typeof window === "undefined") {
+      return;
+    }
+
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify(Array.from(seenIds.values())),
+    );
+  }, [ready, seenIds]);
+
+  const toggleSeen = (id: number) => {
+    setSeenIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  return {
+    seenIds,
+    ready,
+    toggleSeen,
+  };
+}
+
+export function isAircraftSeen(seenIds: Set<number>, aircraftId: number) {
+  return seenIds.has(aircraftId);
+}

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -13,6 +13,7 @@ const navLinks = [
   { label: "Airports", href: "/airports" },
   { label: "Live Map", href: "/live" },
   { label: "Frequencies", href: "/frequencies" },
+  { label: "Fleets", href: "/fleets" },
   { label: "Logbook", href: "/logbook" },
 ];
 
@@ -80,6 +81,28 @@ const features: Feature[] = [
       </svg>
     ),
     badge: "Live layers",
+  },
+  {
+    title: "Airline Fleets",
+    description: "Dive into each carrier's fleet, grouped by type with instant seen progress from your logbook.",
+    href: "/fleets",
+    icon: (
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        fill="none"
+        strokeWidth="1.5"
+        className="h-6 w-6 text-cyan-300"
+      >
+        <path
+          d="m3 6 9-3 9 3m-16 4 7-2 7 2m-14 4 9-3 9 3"
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path d="M3 6v12l9 3 9-3V6" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" />
+      </svg>
+    ),
   },
   {
     title: "Live ADS-B",


### PR DESCRIPTION
## Summary
- add a fleets page that groups aircraft by airline and surfaces logbook seen progress
- extract a reusable hook for storing seen aircraft so the fleet browser and logbook share the same state
- link the new fleets experience from the site navigation and homepage feature grid

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd9203434883248689c3a085bd543b