### PR TITLE
Document aircraft seeding workflow and add requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+Django==5.2.6
+djangorestframework>=3.15,<4.0
+django-cors-headers>=4.0,<5.0
+djangorestframework-simplejwt>=5.3,<6.0


### PR DESCRIPTION
## Summary
- add a top-level requirements.txt that pins Django and supporting backend libraries
- expand the aircraft database guide with prerequisites for installing deps, running migrations, and validating the seeded fleet

## Testing
- `python manage.py migrate` *(fails: django not installed in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd95350b9c8324866848cb5ca795f9