### PR TITLE
Add interactive ADS-B aircraft selection view

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -42,6 +42,12 @@ body {
   backdrop-filter: blur(2px);
 }
 
+.adsb-marker--selected {
+  background: rgba(14, 165, 233, 0.9);
+  border-color: rgba(250, 204, 21, 0.85);
+  box-shadow: 0 0 22px rgba(250, 204, 21, 0.55);
+}
+
 .adsb-marker__arrow {
   position: absolute;
   top: -14px;


### PR DESCRIPTION
## Summary
- allow selecting flights from the ADS-B map or list to reveal a detailed telemetry card
- highlight selected aircraft markers and preserve the selection when the feed refreshes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd9d6c1c448324be5bd6981d0a4705