### PR TITLE
Ensure aircraft feed fallback dataset resolves correctly

### DIFF
--- a/core/services/aircraft_feed.py
+++ b/core/services/aircraft_feed.py
@@ -24,7 +24,19 @@ class AircraftFeedError(RuntimeError):
 logger = logging.getLogger(__name__)
 
 
-FALLBACK_DATASET = Path(__file__).resolve().parent / "data" / "aircraft_sample.csv"
+FALLBACK_DATASET = (
+    Path(__file__).resolve().parent / "data" / "aircraft_sample.csv"
+)
+
+if not FALLBACK_DATASET.exists():
+    # Older releases bundled the sample dataset under ``core/data`` rather than
+    # ``core/services/data``.  In development environments the file still lives
+    # there, which meant the fallback path silently pointed at a non-existent
+    # file and the aircraft list ended up empty.  Look one directory higher as a
+    # backwards compatible fallback so the bundled dataset is always found.
+    FALLBACK_DATASET = (
+        Path(__file__).resolve().parent.parent / "data" / "aircraft_sample.csv"
+    )
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Summary
- ensure the aircraft feed fallback dataset checks the legacy `core/data` location when the new path is missing so the bundled sample data is picked up
- add explanatory comments clarifying the backward-compatible search logic

## Testing
- python manage.py test core *(fails: existing AssertionError about router basename due to viewset without queryset)*

------
https://chatgpt.com/codex/tasks/task_e_68dd9f8da5ec832488cf47e4e2cd8cd2