### PR TITLE
Fix fetchFlights callback closure

### DIFF
--- a/web/src/app/live/page.tsx
+++ b/web/src/app/live/page.tsx
@@ -381,8 +381,15 @@ export default function LiveAdsbPage() {
         scheduleNextFetch();
       }
     }
-
-    
+  }, [
+    limitToMapView,
+    originFilter,
+    destinationFilter,
+    minAltitude,
+    maxAltitude,
+    scheduleNextFetch,
+    updateMarkers,
+  ]);
 
   useEffect(() => {
     fetchFlightsRef.current = fetchFlights;


### PR DESCRIPTION
## Summary
- add the missing closing syntax for the fetchFlights useCallback
- include the required dependency list so the callback updates when filters change

## Testing
- npm run build *(fails: Next.js font download blocked in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dda205c4b08324999b340205f564fd