### PR TITLE
Fix router registration error for user seen viewset

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -40,6 +40,7 @@ class AircraftViewSet(viewsets.ModelViewSet):
     permission_classes = [permissions.AllowAny]
 
 class UserSeenViewSet(viewsets.ModelViewSet):
+    queryset = UserSeen.objects.none()
     serializer_class = UserSeenSerializer
     permission_classes = [permissions.IsAuthenticated]
 


### PR DESCRIPTION
## Summary
- add a queryset to the user seen viewset so the DRF router can derive its basename
- unblock the API router from initialising so airport listings can load again

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dda2df0b048324a4ede0e06e3b4be0