### PR TITLE
Allow unlimited aircraft feed imports

### DIFF
--- a/core/tests.py
+++ b/core/tests.py
@@ -54,6 +54,20 @@ class FetchLiveFleetTests(SimpleTestCase):
 
         self.assertEqual(len(results), 1)
 
+    @override_settings(AIRCRAFT_FEED_MAX_RESULTS=0)
+    def test_fetch_live_fleet_reads_full_dataset_when_cap_disabled(self):
+        with mock.patch.object(aircraft_feed, "_open_feed", side_effect=self._mock_feed):
+            results = aircraft_feed.fetch_live_fleet(use_cache=False)
+
+        self.assertEqual(len(results), 3)
+
+    @override_settings(AIRCRAFT_FEED_MAX_RESULTS=2)
+    def test_fetch_live_fleet_limit_zero_overrides_cap(self):
+        with mock.patch.object(aircraft_feed, "_open_feed", side_effect=self._mock_feed):
+            results = aircraft_feed.fetch_live_fleet(limit=0, use_cache=False)
+
+        self.assertEqual(len(results), 3)
+
     def test_fetch_live_fleet_falls_back_to_sample_dataset(self):
         with mock.patch.object(
             aircraft_feed,

--- a/docs/aircraft-database.md
+++ b/docs/aircraft-database.md
@@ -54,7 +54,7 @@ The command uses the same settings as the live fleet endpoint. To change the sou
 - `AIRCRAFT_FEED_MAX_RESULTS`
 - `AIRCRAFT_FEED_TIMEOUT`
 
-Adjust `AIRCRAFT_FEED_MAX_RESULTS` if you want to prefill the database with a larger slice of the fleet for autocomplete in the logbook.
+Adjust `AIRCRAFT_FEED_MAX_RESULTS` if you want to prefill the database with a larger slice of the fleet for autocomplete in the logbook. Set it to `0` (or a negative number) to remove the cap entirely and import the complete feed. You can also pass `--limit 0` to the sync commands when you only want the full world fleet for a single run without changing your environment configuration.
 
 ## Verifying the Data
 


### PR DESCRIPTION
## Summary
- allow the aircraft feed sync to import the full dataset when the limit flag or environment cap is set to zero
- adjust caching logic and add regression tests covering uncapped imports
- document how to disable the maximum results limit when populating the fleet database

## Testing
- python manage.py test core *(fails: existing router basename assertion in core.urls)*

------
https://chatgpt.com/codex/tasks/task_e_68dda33987348324a8c14abbd9beb89a